### PR TITLE
Added else if to handle the single match result being a Resource rather than Iterable

### DIFF
--- a/cql-engine-fhir/src/main/java/org/opencds/cqf/cql/data/fhir/FhirMeasureEvaluator.java
+++ b/cql-engine-fhir/src/main/java/org/opencds/cqf/cql/data/fhir/FhirMeasureEvaluator.java
@@ -52,6 +52,11 @@ public class FhirMeasureEvaluator {
                         }
                     }
                 }
+                else if (result instanceof Resource) {
+                	count++;
+                	resources.put(((Resource)result).getId(), (Resource)result);
+                }
+                
                 MeasureReport.MeasureReportGroupPopulationComponent populationReport = new MeasureReport.MeasureReportGroupPopulationComponent();
                 populationReport.setCount(count);
                 populationReport.setType(population.getType().toCode()); // TODO: It's not clear why these properties are represented differently in the HAPI client, they're the same type in the FHIR spec...


### PR DESCRIPTION
When the match is a single Resource it returns the Resource itself rather than a FhirBundleCursor that is Iterable.