### PR TITLE
Interval equivalence fixes for issue https://github.com/DBCG/cql_engine/issues/39 

### DIFF
--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/EquivalentEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/EquivalentEvaluator.java
@@ -2,6 +2,7 @@ package org.opencds.cqf.cql.elm.execution;
 
 import org.opencds.cqf.cql.execution.Context;
 import org.opencds.cqf.cql.runtime.DateTime;
+import org.opencds.cqf.cql.runtime.Interval;
 import org.opencds.cqf.cql.runtime.Time;
 import org.opencds.cqf.cql.runtime.Tuple;
 
@@ -71,6 +72,14 @@ public class EquivalentEvaluator extends org.cqframework.cql.elm.execution.Equiv
             }
 
             return true;
+        }
+
+        else if (left instanceof Interval) {
+            Object startEquivalence = equivalent(((Interval) left).getStart(), ((Interval) right).getStart());
+            Object endEquivalence = equivalent(((Interval) left).getEnd(), ((Interval) right).getEnd());
+            return (startEquivalence == null && endEquivalence == null)
+                    || (startEquivalence != null && endEquivalence != null
+                    && (Boolean) startEquivalence && (Boolean) endEquivalence);
         }
 
         else if (left instanceof Tuple) {

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/runtime/Interval.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/runtime/Interval.java
@@ -115,9 +115,9 @@ public class Interval {
     }
 
     public Boolean equal(Interval other) {
-        return this.getLow() != null && EqualEvaluator.equal(this.getLow(), other.getLow())
+        return this.getLow() != null && EqualEvaluator.equal(this.getStart(), other.getStart())
                 && this.getLowClosed() == other.getLowClosed()
-                && this.getHigh() != null && EqualEvaluator.equal(this.getHigh(), other.getHigh())
+                && this.getHigh() != null && EqualEvaluator.equal(this.getEnd(), other.getEnd())
                 && this.getHighClosed() == other.getHighClosed();
     }
 

--- a/cql-engine/src/test/java/org/opencds/cqf/cql/execution/CqlTypesTest.java
+++ b/cql-engine/src/test/java/org/opencds/cqf/cql/execution/CqlTypesTest.java
@@ -162,6 +162,9 @@ public class CqlTypesTest extends CqlExecutionTestBase {
         Object result = context.resolveExpressionRef("Issue33").getExpression().evaluate(context);
         assertThat(((DateTime)((Interval)result).getStart()).getPartial(), is(new Partial(DateTime.getFields(6), new int[] {2017, 12, 20, 11, 0, 0})));
         assertThat(((DateTime)((Interval)result).getEnd()).getPartial(), is(new Partial(DateTime.getFields(7), new int[] {2017, 12, 20, 23, 59, 59, 999})));
+
+        result = context.resolveExpressionRef("EquivalentIntervals").getExpression().evaluate(context);
+        assertThat(result, is(true));
     }
 
     /**

--- a/cql-engine/src/test/resources/org/opencds/cqf/cql/execution/CqlTypesTest.cql
+++ b/cql-engine/src/test/resources/org/opencds/cqf/cql/execution/CqlTypesTest.cql
@@ -58,6 +58,20 @@ define function CalendarDayOf(Value DateTime):
 
 define Issue33: CalendarDayOf(TestDateTime1)
 
+define x:
+    Interval[
+        @2017-12-20T11:00:00,
+        DateTime(
+            year from (@2017-12-20T11:00:00 + 1 day),
+            month from (@2017-12-20T11:00:00 + 1 day),
+            day from (@2017-12-20T11:00:00 + 1 day),
+            0, 0, 0, 0,
+            timezone from (@2017-12-20T11:00:00 + 1 day)
+        )
+    )
+define y: Interval [ @2017-12-20T11:00:00, @2017-12-20T23:59:59.999 ]
+define EquivalentIntervals: Equivalent(x,y)
+
 //Quantity
 define QuantityTest: 150.2 'lbs'
 define QuantityTest2: 2.5589 'eskimo kisses'

--- a/cql-engine/src/test/resources/org/opencds/cqf/cql/execution/TestIsolatedCqlExprs/tests/CqlTypesTest.xml
+++ b/cql-engine/src/test/resources/org/opencds/cqf/cql/execution/TestIsolatedCqlExprs/tests/CqlTypesTest.xml
@@ -162,29 +162,6 @@
 				)
 			</expression>
 			<output>Interval [ @2017-12-20T11:00:00, @2017-12-20T23:59:59.999 ]</output>
-			<!--
-				TODO: The original test was specifically about testing function
-				call stacks, which are currently not supported by this test framework.
-				This was the original holistic test CQL:
-					// Interval
-					define TestDateTime1: @2017-12-20T11:00:00
-					define function ToDate(Value DateTime):
-						DateTime(year from Value, month from Value, day from Value, 0, 0, 0, 0, timezone from Value)
-					define function CalendarDayOf(Value DateTime):
-						Interval[Value, ToDate((Value + 1 day)))
-					define Issue33: CalendarDayOf(TestDateTime1)
-				This was the corresponding Java:
-					public void testInterval() {
-						Context context = new Context(library);
-						Object result = context.resolveExpressionRef("Issue33").getExpression().evaluate(context);
-						assertThat(((DateTime)((Interval)result).getStart()).getPartial(),
-							is(new Partial(DateTime.getFields(6), new int[] {2017, 12, 20, 11, 0, 0})));
-						assertThat(((DateTime)((Interval)result).getEnd()).getPartial(),
-							is(new Partial(DateTime.getFields(7), new int[] {2017, 12, 20, 23, 59, 59, 999})));
-					}
-			-->
-			<!-- TODO: Fix Engine to make Equivalent() return true for the
-			above pair, which output identical looking values. -->
 		</test>
 		<test name="Issue39">
 			<expression>

--- a/cql-engine/src/test/resources/org/opencds/cqf/cql/execution/TestIsolatedCqlExprs/tests/CqlTypesTest.xml
+++ b/cql-engine/src/test/resources/org/opencds/cqf/cql/execution/TestIsolatedCqlExprs/tests/CqlTypesTest.xml
@@ -186,6 +186,21 @@
 			<!-- TODO: Fix Engine to make Equivalent() return true for the
 			above pair, which output identical looking values. -->
 		</test>
+		<test name="Issue39">
+			<expression>
+				Interval[
+					@2017-12-20T11:00:00,
+					DateTime(
+					year from (@2017-12-20T11:00:00 + 1 day),
+					month from (@2017-12-20T11:00:00 + 1 day),
+					day from (@2017-12-20T11:00:00 + 1 day),
+					0, 0, 0, 0,
+					timezone from (@2017-12-20T11:00:00 + 1 day)
+					)
+				) ~ Interval [ @2017-12-20T11:00:00, @2017-12-20T23:59:59.999 ]
+			</expression>
+			<output>true</output>
+		</test>
 	</group>
 	<group name="Quantity">
 		<test name="QuantityTest">


### PR DESCRIPTION
Added logic for Interval types in EquivalenceEvaluator.
Refactored Interval.Equal to respect boundaries.