### PR TITLE
Fixed InEvaluator

### DIFF
--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/InEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/InEvaluator.java
@@ -34,10 +34,6 @@ public class InEvaluator extends org.cqframework.cql.elm.execution.In {
 
     public static Boolean in(Object left, Object right, String precision) {
 
-        if (left == null) {
-            return null;
-        }
-
         if (right == null) {
             return false;
         }
@@ -65,6 +61,10 @@ public class InEvaluator extends org.cqframework.cql.elm.execution.In {
         }
 
         else if (right instanceof Interval) {
+            if (left == null) {
+                return null;
+            }
+
             Object rightStart = ((Interval) right).getStart();
             Object rightEnd = ((Interval) right).getEnd();
 

--- a/cql-engine/src/test/java/org/opencds/cqf/cql/execution/CqlIntervalOperatorsTest.java
+++ b/cql-engine/src/test/java/org/opencds/cqf/cql/execution/CqlIntervalOperatorsTest.java
@@ -245,6 +245,12 @@ public class CqlIntervalOperatorsTest extends CqlExecutionTestBase {
         result = context.resolveExpressionRef("TestNullElement2").getExpression().evaluate(context);
         assertThat(result, is(false));
 
+        result = context.resolveExpressionRef("TestNullElement3").getExpression().evaluate(context);
+        assertThat(result, is(true));
+
+        result = context.resolveExpressionRef("TestNullElement4").getExpression().evaluate(context);
+        assertThat(result, is(true));
+
         result = context.resolveExpressionRef("IntegerIntervalContainsTrue").getExpression().evaluate(context);
         assertThat(result, is(true));
 

--- a/cql-engine/src/test/java/org/opencds/cqf/cql/execution/CqlListOperatorsTest.java
+++ b/cql-engine/src/test/java/org/opencds/cqf/cql/execution/CqlListOperatorsTest.java
@@ -41,7 +41,7 @@ public class CqlListOperatorsTest extends CqlExecutionTestBase {
         Context context = new Context(library);
 
         Object result = context.resolveExpressionRef("ContainsABNullHasNull").getExpression().evaluate(context);
-        assertThat(result, is(nullValue()));
+        assertThat(result, is(true));
 
         result = context.resolveExpressionRef("ContainsNullFirst").getExpression().evaluate(context);
         assertThat(result, is(false));
@@ -276,10 +276,13 @@ public class CqlListOperatorsTest extends CqlExecutionTestBase {
         Context context = new Context(library);
 
         Object result = context.resolveExpressionRef("InNullEmpty").getExpression().evaluate(context);
-        assertThat(result, is(nullValue()));
+        assertThat(result, is(false));
 
         result = context.resolveExpressionRef("InNullAnd1Null").getExpression().evaluate(context);
-        assertThat(result, is(nullValue()));
+        assertThat(result, is(true));
+
+        result = context.resolveExpressionRef("GithubIssue71").getExpression().evaluate(context);
+        assertThat(result, is(true));
 
         result = context.resolveExpressionRef("In1Null").getExpression().evaluate(context);
         assertThat(result, is(false));

--- a/cql-engine/src/test/resources/org/opencds/cqf/cql/execution/CqlIntervalOperatorsTest.cql
+++ b/cql-engine/src/test/resources/org/opencds/cqf/cql/execution/CqlIntervalOperatorsTest.cql
@@ -69,6 +69,8 @@ define TimeCollapse2: collapse { Interval[@T01:59:59.999, @T10:59:59.999], Inter
 define TestContainsNull: IntegerIntervalTest contains null
 define TestNullElement1: null contains 5
 define TestNullElement2: Interval[null, 5] contains 10
+define TestNullElement3: Interval[5, null] contains 10
+define TestNullElement4: Interval[null, 11] contains 10
 define IntegerIntervalContainsTrue: IntegerIntervalTest contains 5
 define IntegerIntervalContainsFalse: IntegerIntervalTest contains 25
 define DecimalIntervalContainsTrue: DecimalIntervalTest contains 8.0

--- a/cql-engine/src/test/resources/org/opencds/cqf/cql/execution/CqlListOperatorsTest.cql
+++ b/cql-engine/src/test/resources/org/opencds/cqf/cql/execution/CqlListOperatorsTest.cql
@@ -83,6 +83,7 @@ define FirstTime: First({ @T15:59:59.999, @T20:59:59.999 })
 //In
 define InNullEmpty: null in {}
 define InNullAnd1Null: null in { 1, null }
+define GithubIssue71: null in { 1, 2, 3, null }
 define In1Null: 1 in null
 define In1And12: 1 in { 1, 2 }
 define In3And12: 3 in { 1, 2 }

--- a/cql-engine/src/test/resources/org/opencds/cqf/cql/execution/TestIsolatedCqlExprs/tests/CqlIntervalOperatorsTest.xml
+++ b/cql-engine/src/test/resources/org/opencds/cqf/cql/execution/TestIsolatedCqlExprs/tests/CqlIntervalOperatorsTest.xml
@@ -247,6 +247,14 @@
 			<expression>Interval[null, 5] contains 10</expression>
 			<output>false</output>
 		</test>
+		<test name="TestNullElement3">
+			<expression>Interval[5, null] contains 10</expression>
+			<output>true</output>
+		</test>
+		<test name="TestNullElement4">
+			<expression>Interval[null, 11] contains 10</expression>
+			<output>true</output>
+		</test>
 		<test name="IntegerIntervalContainsTrue">
 			<expression>Interval[1, 10] contains 5</expression>
 			<output>true</output>

--- a/cql-engine/src/test/resources/org/opencds/cqf/cql/execution/TestIsolatedCqlExprs/tests/CqlListOperatorsTest.xml
+++ b/cql-engine/src/test/resources/org/opencds/cqf/cql/execution/TestIsolatedCqlExprs/tests/CqlListOperatorsTest.xml
@@ -29,7 +29,7 @@
 	<group name="Contains">
 		<test name="ContainsABNullHasNull">
 			<expression>{ 'a', 'b', null } contains null</expression>
-			<output>null</output>
+			<output>true</output>
 		</test>
 		<test name="ContainsNullFirst">
 			<expression>{ null, 'b', 'c' } contains 'a'</expression>
@@ -258,11 +258,15 @@
 	<group name="In">
 		<test name="InNullEmpty">
 			<expression>null in {}</expression>
-			<output>null</output>
+			<output>false</output>
 		</test>
 		<test name="InNullAnd1Null">
 			<expression>null in { 1, null }</expression>
-			<output>null</output>
+			<output>true</output>
+		</test>
+		<test name="GithubIssue71">
+			<expression>null in { 1, 2, 3, null }</expression>
+			<output>true</output>
 		</test>
 		<test name="In1Null">
 			<expression>1 in null</expression>


### PR DESCRIPTION
Fix for issue #71. InEvaluator had an invalid null check that was messing up membership checks. Also corrected some invalid tests and added some new ones.