### PR TITLE
Issue #36 - make Engine handle minimum Integer literal -2147483648

### DIFF
--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/NegateEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/NegateEvaluator.java
@@ -1,5 +1,6 @@
 package org.opencds.cqf.cql.elm.execution;
 
+import org.cqframework.cql.elm.execution.Expression;
 import org.opencds.cqf.cql.execution.Context;
 import org.opencds.cqf.cql.runtime.Quantity;
 import java.math.BigDecimal;
@@ -42,7 +43,20 @@ public class NegateEvaluator extends org.cqframework.cql.elm.execution.Negate {
 
     @Override
     public Object evaluate(Context context) {
-        Object source = getOperand().evaluate(context);
+        Expression operand = getOperand();
+
+        // Special case to handle literals of the minimum Integer value
+        // since usual implementation would try to cast 2147483648 as a
+        // signed 32 bit signed integer and throw
+        // java.lang.NumberFormatException: For input string: "2147483648".
+        if (operand instanceof LiteralEvaluator
+            && ((LiteralEvaluator)operand).getValueType().getLocalPart().equals("Integer")
+            && ((LiteralEvaluator)operand).getValue().equals("2147483648")
+        ) {
+            return -2147483648;
+        }
+
+        Object source = operand.evaluate(context);
 
         return context.logTrace(this.getClass(), negate(source), source);
     }

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/NegateEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/NegateEvaluator.java
@@ -49,11 +49,9 @@ public class NegateEvaluator extends org.cqframework.cql.elm.execution.Negate {
         // since usual implementation would try to cast 2147483648 as a
         // signed 32 bit signed integer and throw
         // java.lang.NumberFormatException: For input string: "2147483648".
-        if (operand instanceof LiteralEvaluator
-            && ((LiteralEvaluator)operand).getValueType().getLocalPart().equals("Integer")
-            && ((LiteralEvaluator)operand).getValue().equals("2147483648")
-        ) {
-            return -2147483648;
+        if (operand instanceof LiteralEvaluator && ((LiteralEvaluator)operand).getValue().equals("2147483648"))
+        {
+            return Integer.MIN_VALUE;
         }
 
         Object source = operand.evaluate(context);

--- a/cql-engine/src/test/java/org/opencds/cqf/cql/execution/TestIsolatedCqlExprs.java
+++ b/cql-engine/src/test/java/org/opencds/cqf/cql/execution/TestIsolatedCqlExprs.java
@@ -157,7 +157,7 @@ public class TestIsolatedCqlExprs {
         }
     }
 
-    //@Test
+    @Test
     public void testIsolatedCqlExprs() {
         // Load Test cases from org/opencds/cqf/cql/execution/TestIsolatedCqlExprs/tests/*.xml
         String testsDirPath = "TestIsolatedCqlExprs/tests";

--- a/cql-engine/src/test/java/org/opencds/cqf/cql/execution/TestIsolatedCqlExprs.java
+++ b/cql-engine/src/test/java/org/opencds/cqf/cql/execution/TestIsolatedCqlExprs.java
@@ -157,7 +157,7 @@ public class TestIsolatedCqlExprs {
         }
     }
 
-    @Test
+    //@Test
     public void testIsolatedCqlExprs() {
         // Load Test cases from org/opencds/cqf/cql/execution/TestIsolatedCqlExprs/tests/*.xml
         String testsDirPath = "TestIsolatedCqlExprs/tests";

--- a/cql-engine/src/test/resources/org/opencds/cqf/cql/execution/TestIsolatedCqlExprs/tests/CqlArithmeticFunctionsTest.xml
+++ b/cql-engine/src/test/resources/org/opencds/cqf/cql/execution/TestIsolatedCqlExprs/tests/CqlArithmeticFunctionsTest.xml
@@ -263,7 +263,6 @@
 		<test name="IntegerMinValue">
 			<expression>minimum Integer</expression>
 			<output>-2147483648</output>
-			<!-- TODO: make Engine parse -2147483648 holistically not as a negated positive -->
 		</test>
 		<test name="DecimalMinValue">
 			<expression>minimum Decimal</expression>

--- a/cql-engine/src/test/resources/org/opencds/cqf/cql/execution/TestIsolatedCqlExprs/tests/ValueLiteralsAndSelectors.xml
+++ b/cql-engine/src/test/resources/org/opencds/cqf/cql/execution/TestIsolatedCqlExprs/tests/ValueLiteralsAndSelectors.xml
@@ -100,7 +100,6 @@
 		<test name="IntegerNeg2Pow31IntegerMinValue">
 			<expression>-2147483648</expression>
 			<output>-Power(2,30)-Power(2,30)</output>
-			<!-- TODO: Fix evaluation failed in Engine: java.lang.NumberFormatException: For input string: "2147483648" -->
 		</test>
 		<test name="Integer2Pow31ToInf1">
 			<expression invalid="true">2147483649</expression>


### PR DESCRIPTION
This commit fixes these 2 failing tests:

   * CqlArithmeticFunctionsTest.xml -> MinValue -> IntegerMinValue
   * ValueLiteralsAndSelectors.xml -> Integer -> IntegerNeg2Pow31IntegerMinValue
