### PR TITLE
Fix #106 default precision

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ allprojects {
     apply plugin: 'eclipse'
 
     group = 'org.opencds.cqf'
-    version = '1.2.48-SNAPSHOT'
+    version = '1.2.49-SNAPSHOT'
 }
 
 subprojects {

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/AfterEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/AfterEvaluator.java
@@ -61,7 +61,7 @@ public class AfterEvaluator extends org.cqframework.cql.elm.execution.After {
             BaseTemporal rightTemporal = (BaseTemporal) right;
 
             if (precision == null) {
-                precision = "millisecond";
+                precision = BaseTemporal.getHighestPrecision(leftTemporal, rightTemporal);
             }
 
             int idx = leftTemporal.getIsDateTime() ? DateTime.getFieldIndex(precision) : Time.getFieldIndex(precision);

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/BeforeEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/BeforeEvaluator.java
@@ -59,7 +59,7 @@ public class BeforeEvaluator extends org.cqframework.cql.elm.execution.Before {
             BaseTemporal rightTemporal = (BaseTemporal) right;
 
             if (precision == null) {
-                precision = "millisecond";
+                precision = BaseTemporal.getHighestPrecision(leftTemporal, rightTemporal);
             }
 
             int idx = leftTemporal.getIsDateTime() ? DateTime.getFieldIndex(precision) : Time.getFieldIndex(precision);

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/SameAsEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/SameAsEvaluator.java
@@ -32,13 +32,13 @@ public class SameAsEvaluator extends org.cqframework.cql.elm.execution.SameAs {
             return null;
         }
 
-        if (precision == null) {
-            precision = "millisecond";
-        }
-
         if (left instanceof BaseTemporal && right instanceof BaseTemporal) {
             BaseTemporal leftTemporal = (BaseTemporal) left;
             BaseTemporal rightTemporal = (BaseTemporal) right;
+
+            if (precision == null) {
+                precision = BaseTemporal.getHighestPrecision(leftTemporal, rightTemporal);
+            }
 
             int idx = DateTime.getFieldIndex(precision);
 

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/SameOrAfterEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/SameOrAfterEvaluator.java
@@ -77,13 +77,13 @@ public class SameOrAfterEvaluator extends org.cqframework.cql.elm.execution.Same
             return onOrAfter(left, right, precision);
         }
 
-        if (precision == null) {
-            precision = "millisecond";
-        }
-
         if (left instanceof BaseTemporal && right instanceof BaseTemporal) {
             BaseTemporal leftTemporal = (BaseTemporal) left;
             BaseTemporal rightTemporal = (BaseTemporal) right;
+
+            if (precision == null) {
+                precision = BaseTemporal.getHighestPrecision(leftTemporal, rightTemporal);
+            }
 
             int idx = DateTime.getFieldIndex(precision);
 

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/SameOrBeforeEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/SameOrBeforeEvaluator.java
@@ -76,13 +76,13 @@ public class SameOrBeforeEvaluator extends org.cqframework.cql.elm.execution.Sam
             return onOrBefore(left, right, precision);
         }
 
-        if (precision == null) {
-            precision = "millisecond";
-        }
-
         if (left instanceof BaseTemporal && right instanceof BaseTemporal) {
             BaseTemporal leftTemporal = (BaseTemporal) left;
             BaseTemporal rightTemporal = (BaseTemporal) right;
+
+            if (precision == null) {
+                precision = BaseTemporal.getHighestPrecision(leftTemporal, rightTemporal);
+            }
 
             int idx = DateTime.getFieldIndex(precision);
 

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/runtime/BaseTemporal.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/runtime/BaseTemporal.java
@@ -173,9 +173,11 @@ public abstract class BaseTemporal implements CqlType, Comparable<BaseTemporal> 
     }
 
     public static String getHighestPrecision(BaseTemporal ... values) {
-        int max = 6;
+        int max = 0;
         for (BaseTemporal baseTemporal : values) {
-            max = baseTemporal.partial.size() - 1;
+            if (baseTemporal.partial.size() - 1 > max) {
+                max = baseTemporal.partial.size() - 1;
+            }
         }
 
         return values[0] instanceof DateTime ? DateTime.getUnit(max) : Time.getUnit(max);

--- a/cql-engine/src/test/java/org/opencds/cqf/cql/execution/CqlIntervalOperatorsTest.java
+++ b/cql-engine/src/test/java/org/opencds/cqf/cql/execution/CqlIntervalOperatorsTest.java
@@ -276,6 +276,9 @@ public class CqlIntervalOperatorsTest extends CqlExecutionTestBase {
         result = context.resolveExpressionRef("DateTimeContainsTrue").getExpression().evaluate(context);
         assertThat(result, is(true));
 
+        result = context.resolveExpressionRef("DateTimeContainsTrue2").getExpression().evaluate(context);
+        assertThat(result, is(true));
+
         result = context.resolveExpressionRef("DateTimeContainsFalse").getExpression().evaluate(context);
         assertThat(result, is(false));
 

--- a/cql-engine/src/test/resources/org/opencds/cqf/cql/execution/CqlIntervalOperatorsTest.cql
+++ b/cql-engine/src/test/resources/org/opencds/cqf/cql/execution/CqlIntervalOperatorsTest.cql
@@ -77,10 +77,11 @@ define DecimalIntervalContainsTrue: DecimalIntervalTest contains 8.0
 define DecimalIntervalContainsFalse: DecimalIntervalTest contains 255.0
 define QuantityIntervalContainsTrue: QuantityIntervalTest contains 2.0 'g'
 define QuantityIntervalContainsFalse: QuantityIntervalTest contains 100.0 'g'
-define DateTimeContainsNull: Interval[DateTime(2012, 1, 1), DateTime(2012, 1, 15)] contains DateTime(2012, 1, 10)
+define DateTimeContainsNull: Interval[DateTime(2012, 1, 1), DateTime(2012, 1, 15)] contains DateTime(2012, 1, 15, 12)
 define DateTimeContainsTrue: Interval[DateTime(2012, 1, 1), DateTime(2012, 1, 15)] contains day of DateTime(2012, 1, 10)
+define DateTimeContainsTrue2: Interval[DateTime(2012, 1, 1), DateTime(2012, 1, 15)] contains DateTime(2012, 1, 10)
 define DateTimeContainsFalse: Interval[DateTime(2012, 1, 1), DateTime(2012, 1, 15)] contains day of DateTime(2012, 1, 16)
-define TimeContainsNull: Interval[@T01:59:59, @T10:59:59] contains @T05:59:59
+define TimeContainsNull: Interval[@T01:59:59, @T10:59:59] contains @T05:59:59.999
 define TimeContainsTrue: Interval[@T01:59:59.999, @T10:59:59.999] contains @T05:59:59.999
 define TimeContainsFalse: Interval[@T01:59:59.999, @T10:59:59.999] contains @T15:59:59.999
 
@@ -100,7 +101,7 @@ define DecimalIntervalEndsFalse: DecimalIntervalTest2 ends DecimalIntervalTest
 define QuantityIntervalEndsTrue: QuantityIntervalTest3 ends QuantityIntervalTest
 define QuantityIntervalEndsFalse: QuantityIntervalTest2 ends QuantityIntervalTest
 define DateTimeEndsTrue: Interval[DateTime(2012, 1, 5), DateTime(2012, 1, 15)] ends day of Interval[DateTime(2012, 1, 1), DateTime(2012, 1, 15)]
-define DateTimeEndsNull: Interval[DateTime(2012, 1, 5), DateTime(2012, 1, 15)] ends Interval[DateTime(2012, 1, 1), DateTime(2012, 1, 15)]
+define DateTimeEndsNull: Interval[DateTime(2012, 1, 5), DateTime(2012, 1, 15)] ends Interval[DateTime(2012, 1, 1, 12), DateTime(2012, 1, 15, 12)]
 define DateTimeEndsFalse: Interval[DateTime(2012, 1, 5), DateTime(2012, 1, 15)] ends day of Interval[DateTime(2012, 1, 1), DateTime(2012, 1, 16)]
 define TimeEndsTrue: Interval[@T05:59:59.999, @T10:59:59.999] ends Interval[@T01:59:59.999, @T10:59:59.999]
 define TimeEndsFalse: Interval[@T05:59:59.999, @T10:59:59.999] ends Interval[@T01:59:59.999, @T11:59:59.999]
@@ -143,7 +144,7 @@ define DecimalIntervalInFalse: -2.0 in DecimalIntervalTest
 define QuantityIntervalInTrue: 1.0 'g' in QuantityIntervalTest
 define QuantityIntervalInFalse: 55.0 'g' in QuantityIntervalTest
 define DateTimeInTrue: DateTime(2012, 1, 7) in day of Interval[DateTime(2012, 1, 5), DateTime(2012, 1, 15)]
-define DateTimeInNullPrecision: DateTime(2012, 1, 7) in Interval[DateTime(2012, 1, 5), DateTime(2012, 1, 15)]
+define DateTimeInNullPrecision: DateTime(2012, 1, 7, 12) in Interval[DateTime(2012, 1, 5), DateTime(2012, 1, 15)]
 define DateTimeInFalse: DateTime(2012, 1, 17) in day of Interval[DateTime(2012, 1, 5), DateTime(2012, 1, 15)]
 define DateTimeInNullTrue: DateTime(2012, 1, 7) in day of Interval[DateTime(2012, 1, 5), null]
 define TimeInTrue: @T07:59:59.999 in Interval[@T05:59:59.999, @T10:59:59.999]
@@ -218,7 +219,7 @@ define DecimalIntervalMeetsFalse: Interval[3.01, 5.00000001] meets Interval[5.5,
 define QuantityIntervalMeetsTrue: Interval[3.01 'g', 5.00000001 'g'] meets Interval[5.00000002 'g', 8.50 'g']
 define QuantityIntervalMeetsFalse: Interval[3.01 'g', 5.00000001 'g'] meets Interval[5.5 'g', 8.50 'g']
 define DateTimeMeetsTrue: Interval[DateTime(2012, 1, 7), DateTime(2012, 1, 14)] meets day of Interval[DateTime(2012, 1, 15), DateTime(2012, 1, 25)]
-define DateTimeMeetsNull: Interval[DateTime(2012, 1, 7), DateTime(2012, 1, 14)] meets Interval[DateTime(2012, 1, 15), DateTime(2012, 1, 25)]
+define DateTimeMeetsNull: Interval[DateTime(2012, 1, 7, 12), DateTime(2012, 1, 14, 12)] meets Interval[DateTime(2012, 1, 15), DateTime(2012, 1, 25)]
 define DateTimeMeetsFalse: Interval[DateTime(2012, 1, 7), DateTime(2012, 1, 14)] meets day of Interval[DateTime(2012, 1, 20), DateTime(2012, 1, 25)]
 define TimeMeetsTrue: Interval[@T04:59:59.999, @T09:59:59.999] meets Interval[@T10:00:00.000, @T19:59:59.999]
 define TimeMeetsFalse: Interval[@T04:59:59.999, @T09:59:59.999] meets Interval[@T10:12:00.000, @T19:59:59.999]
@@ -232,7 +233,7 @@ define DecimalIntervalMeetsBeforeFalse: Interval[8.01, 15.00000001] meets before
 define QuantityIntervalMeetsBeforeTrue: Interval[3.50000001 'g', 5.00000011 'g'] meets before Interval[5.00000012 'g', 8.50 'g']
 define QuantityIntervalMeetsBeforeFalse: Interval[8.01 'g', 15.00000001 'g'] meets before Interval[15.00000000 'g', 18.50 'g']
 define DateTimeMeetsBeforeTrue: Interval[DateTime(2012, 1, 7), DateTime(2012, 1, 14)] meets before day of Interval[DateTime(2012, 1, 15), DateTime(2012, 1, 25)]
-define DateTimeMeetsBeforeNull: Interval[DateTime(2012, 1, 7), DateTime(2012, 1, 14)] meets before Interval[DateTime(2012, 1, 15), DateTime(2012, 1, 25)]
+define DateTimeMeetsBeforeNull: Interval[DateTime(2012, 1, 7), DateTime(2012, 1, 14)] meets before Interval[DateTime(2012, 1, 15, 12), DateTime(2012, 1, 25, 12)]
 define DateTimeMeetsBeforeFalse: Interval[DateTime(2012, 1, 7), DateTime(2012, 1, 14)] meets before day of Interval[DateTime(2012, 1, 20), DateTime(2012, 1, 25)]
 define TimeMeetsBeforeTrue: Interval[@T04:59:59.999, @T09:59:59.999] meets before Interval[@T10:00:00.000, @T19:59:59.999]
 define TimeMeetsBeforeFalse: Interval[@T04:59:59.999, @T09:59:59.999] meets before Interval[@T10:12:00.000, @T19:59:59.999]
@@ -246,7 +247,7 @@ define DecimalIntervalMeetsAfterFalse: Interval[55.00000124, 150.222222] meets a
 define QuantityIntervalMeetsAfterTrue: Interval[55.00000123 'g', 128.032156 'g'] meets after Interval[12.00258 'g', 55.00000122 'g']
 define QuantityIntervalMeetsAfterFalse: Interval[55.00000124 'g', 150.222222 'g'] meets after Interval[12.00258 'g', 55.00000122 'g']
 define DateTimeMeetsAfterTrue: Interval[DateTime(2012, 1, 15), DateTime(2012, 1, 25)] meets after day of Interval[DateTime(2012, 1, 7), DateTime(2012, 1, 14)]
-define DateTimeMeetsAfterNull: Interval[DateTime(2012, 1, 15), DateTime(2012, 1, 25)] meets after Interval[DateTime(2012, 1, 7), DateTime(2012, 1, 14)]
+define DateTimeMeetsAfterNull: Interval[DateTime(2012, 1, 15), DateTime(2012, 1, 25)] meets after Interval[DateTime(2012, 1, 7, 12), DateTime(2012, 1, 14, 12)]
 define DateTimeMeetsAfterFalse: Interval[DateTime(2012, 1, 20), DateTime(2012, 1, 25)] meets after day of Interval[DateTime(2012, 1, 7), DateTime(2012, 1, 14)]
 define TimeMeetsAfterTrue: Interval[@T10:00:00.000, @T19:59:59.999] meets Interval[@T04:59:59.999, @T09:59:59.999]
 define TimeMeetsAfterFalse: Interval[@T10:12:00.000, @T19:59:59.999] meets Interval[@T04:59:59.999, @T09:59:59.999]
@@ -292,7 +293,7 @@ define DecimalIntervalOverlapsFalse: DecimalIntervalTest overlaps DecimalInterva
 define QuantityIntervalOverlapsTrue: QuantityIntervalTest overlaps QuantityIntervalTest3
 define QuantityIntervalOverlapsFalse: QuantityIntervalTest overlaps QuantityIntervalTest2
 define DateTimeOverlapsTrue: Interval[DateTime(2012, 1, 5), DateTime(2012, 1, 25)] overlaps day of Interval[DateTime(2012, 1, 15), DateTime(2012, 1, 28)]
-define DateTimeOverlapsNull: Interval[DateTime(2012, 1, 5), DateTime(2012, 1, 25)] overlaps Interval[DateTime(2012, 1, 15), DateTime(2012, 1, 28)]
+define DateTimeOverlapsNull: Interval[DateTime(2012, 1, 5), DateTime(2012, 1, 25)] overlaps Interval[DateTime(2012, 1, 15, 12), DateTime(2012, 1, 28, 12)]
 define DateTimeOverlapsFalse: Interval[DateTime(2012, 1, 5), DateTime(2012, 1, 25)] overlaps day of Interval[DateTime(2012, 1, 26), DateTime(2012, 1, 28)]
 define TimeOverlapsTrue: Interval[@T10:00:00.000, @T19:59:59.999] overlaps Interval[@T12:00:00.000, @T21:59:59.999]
 define TimeOverlapsFalse: Interval[@T10:00:00.000, @T19:59:59.999] overlaps Interval[@T20:00:00.000, @T21:59:59.999]
@@ -306,7 +307,7 @@ define DecimalIntervalOverlapsBeforeFalse: DecimalIntervalTest3 overlaps before 
 define QuantityIntervalOverlapsBeforeTrue: QuantityIntervalTest overlaps before QuantityIntervalTest3
 define QuantityIntervalOverlapsBeforeFalse: QuantityIntervalTest3 overlaps before QuantityIntervalTest
 define DateTimeOverlapsBeforeTrue: Interval[DateTime(2012, 1, 5), DateTime(2012, 1, 25)] overlaps before day of Interval[DateTime(2012, 1, 15), DateTime(2012, 1, 28)]
-define DateTimeOverlapsBeforeNull: Interval[DateTime(2012, 1, 5), DateTime(2012, 1, 25)] overlaps before Interval[DateTime(2012, 1, 15), DateTime(2012, 1, 28)]
+define DateTimeOverlapsBeforeNull: Interval[DateTime(2012, 1, 5, 12), DateTime(2012, 1, 25, 12)] overlaps before Interval[DateTime(2012, 1, 15), DateTime(2012, 1, 28)]
 define DateTimeOverlapsBeforeFalse: Interval[DateTime(2012, 1, 5), DateTime(2012, 1, 25)] overlaps before day of Interval[DateTime(2012, 1, 26), DateTime(2012, 1, 28)]
 define TimeOverlapsBeforeTrue: Interval[@T10:00:00.000, @T19:59:59.999] overlaps before Interval[@T12:00:00.000, @T21:59:59.999]
 define TimeOverlapsBeforeFalse: Interval[@T10:00:00.000, @T19:59:59.999] overlaps before Interval[@T20:00:00.000, @T21:59:59.999]
@@ -320,7 +321,7 @@ define DecimalIntervalOverlapsAfterFalse: DecimalIntervalTest3 overlaps after De
 define QuantityIntervalOverlapsAfterTrue: QuantityIntervalTest4 overlaps after QuantityIntervalTest
 define QuantityIntervalOverlapsAfterFalse: QuantityIntervalTest3 overlaps after QuantityIntervalTest
 define DateTimeOverlapsAfterTrue: Interval[DateTime(2012, 1, 15), DateTime(2012, 1, 28)] overlaps after day of Interval[DateTime(2012, 1, 5), DateTime(2012, 1, 25)]
-define DateTimeOverlapsAfterNull: Interval[DateTime(2012, 1, 15), DateTime(2012, 1, 28)] overlaps after Interval[DateTime(2012, 1, 5), DateTime(2012, 1, 25)]
+define DateTimeOverlapsAfterNull: Interval[DateTime(2012, 1, 15, 12), DateTime(2012, 1, 28, 12)] overlaps after Interval[DateTime(2012, 1, 5), DateTime(2012, 1, 25)]
 define DateTimeOverlapsAfterFalse: Interval[DateTime(2012, 1, 26), DateTime(2012, 1, 28)] overlaps after day of Interval[DateTime(2012, 1, 5), DateTime(2012, 1, 25)]
 define TimeOverlapsAfterTrue: Interval[@T12:00:00.000, @T21:59:59.999] overlaps after Interval[@T10:00:00.000, @T19:59:59.999]
 define TimeOverlapsAfterFalse: Interval[@T20:00:00.000, @T21:59:59.999] overlaps after Interval[@T10:00:00.000, @T19:59:59.999]
@@ -388,8 +389,8 @@ define DecimalIntervalStartsTrue: DecimalIntervalTest3 starts DecimalIntervalTes
 define DecimalIntervalStartsFalse: DecimalIntervalTest starts DecimalIntervalTest3
 define QuantityIntervalStartsTrue: QuantityIntervalTest3 starts QuantityIntervalTest4
 define QuantityIntervalStartsFalse: QuantityIntervalTest starts QuantityIntervalTest3
-define DateTimeStartsTrue: Interval[DateTime(2012, 1, 5), DateTime(2012, 1, 25)] starts day of Interval[DateTime(2012, 1, 5), DateTime(2012, 1, 27)]
-define DateTimeStartsNull: Interval[DateTime(2012, 1, 5), DateTime(2012, 1, 25)] starts Interval[DateTime(2012, 1, 5), DateTime(2012, 1, 27)]
+define DateTimeStartsTrue: Interval[DateTime(2012, 1, 5, 12), DateTime(2012, 1, 25, 12)] starts day of Interval[DateTime(2012, 1, 5), DateTime(2012, 1, 27)]
+define DateTimeStartsNull: Interval[DateTime(2012, 1, 5, 12), DateTime(2012, 1, 25, 12)] starts Interval[DateTime(2012, 1, 5), DateTime(2012, 1, 27)]
 define DateTimeStartsFalse: Interval[DateTime(2012, 1, 5), DateTime(2012, 1, 25)] starts day of Interval[DateTime(2012, 1, 6), DateTime(2012, 1, 27)]
 define TimeStartsTrue: Interval[@T05:59:59.999, @T15:59:59.999] starts Interval[@T05:59:59.999, @T17:59:59.999]
 define TimeStartsFalse: Interval[@T05:59:59.999, @T15:59:59.999] starts Interval[@T04:59:59.999, @T17:59:59.999]


### PR DESCRIPTION
Refactored date/time operators to default to the highest precision of the passed in args when no precision is specified.