### PR TITLE
Return null when trying to access a non-existent property

### DIFF
--- a/cql-engine-fhir/src/main/java/org/opencds/cqf/cql/model/FhirModelResolver.java
+++ b/cql-engine-fhir/src/main/java/org/opencds/cqf/cql/model/FhirModelResolver.java
@@ -264,6 +264,10 @@ public abstract class FhirModelResolver<BaseType, BaseDateTimeType, TimeType, Si
             child = resolveChoiceProperty(definition, path);
         }
 
+        if (child == null) {
+            throw new DataProviderException(String.format("Unable to resolve path %s.", path));
+        }
+
         try {
             if (value instanceof Iterable) {
                 for (Object val : (Iterable<?>) value) {
@@ -366,7 +370,7 @@ public abstract class FhirModelResolver<BaseType, BaseDateTimeType, TimeType, Si
             }
         }
 
-        throw new UnknownPath(String.format("Unable to resolve path %s for %s", path, definition.getName()));
+        return null;
     }
 
     private Class<?> deepSearch(String typeName) {

--- a/cql-engine-fhir/src/main/java/org/opencds/cqf/cql/model/FhirModelResolver.java
+++ b/cql-engine-fhir/src/main/java/org/opencds/cqf/cql/model/FhirModelResolver.java
@@ -327,6 +327,10 @@ public abstract class FhirModelResolver<BaseType, BaseDateTimeType, TimeType, Si
             child = resolveChoiceProperty(definition, path);
         }
 
+        if (child == null) {
+            return null;
+        }
+
         List<IBase> values = child.getAccessor().getValues(base);
 
         if (values == null || values.isEmpty()) {

--- a/cql-engine-fhir/src/test/java/org/opencds/cqf/cql/model/TestDstu2ModelResolver.java
+++ b/cql-engine-fhir/src/test/java/org/opencds/cqf/cql/model/TestDstu2ModelResolver.java
@@ -2,6 +2,8 @@ package org.opencds.cqf.cql.model;
 
 import org.testng.annotations.Test;
 
+import ca.uhn.fhir.model.dstu2.resource.Patient;
+
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.testng.AssertJUnit.assertTrue;
@@ -164,5 +166,15 @@ public class TestDstu2ModelResolver {
         path = (String)resolver.getContextPath("Patient", "Encounter");
         assertNotNull(path);
         assertTrue(path.equals("patient"));
+    }
+
+    @Test 
+    public void resolveMissingPropertyReturnsNull() {
+        ModelResolver resolver = new Dstu2FhirModelResolver();
+        
+        Patient p = new Patient();
+
+        Object result =resolver.resolvePath(p, "notapath");
+        assertNull(result);
     }
 }

--- a/cql-engine-fhir/src/test/java/org/opencds/cqf/cql/model/TestDstu2ModelResolver.java
+++ b/cql-engine-fhir/src/test/java/org/opencds/cqf/cql/model/TestDstu2ModelResolver.java
@@ -174,7 +174,7 @@ public class TestDstu2ModelResolver {
         
         Patient p = new Patient();
 
-        Object result =resolver.resolvePath(p, "notapath");
+        Object result = resolver.resolvePath(p, "notapath");
         assertNull(result);
     }
 }

--- a/cql-engine-fhir/src/test/java/org/opencds/cqf/cql/model/TestDstu3ModelResolver.java
+++ b/cql-engine-fhir/src/test/java/org/opencds/cqf/cql/model/TestDstu3ModelResolver.java
@@ -15,6 +15,7 @@ import org.hl7.elm.r1.VersionedIdentifier;
 import org.hl7.elm_modelinfo.r1.ClassInfo;
 import org.hl7.elm_modelinfo.r1.TypeInfo;
 import org.hl7.fhir.dstu3.model.Enumeration;
+import org.hl7.fhir.dstu3.model.Patient;
 import org.hl7.fhir.dstu3.model.Enumerations.*;
 import org.opencds.cqf.cql.exception.UnknownType;
 
@@ -225,5 +226,15 @@ public class TestDstu3ModelResolver {
         path = (String)resolver.getContextPath("Patient", "Encounter");
         assertNotNull(path);
         assertTrue(path.equals("subject"));
+    }
+
+    @Test 
+    public void resolveMissingPropertyReturnsNull() {
+        ModelResolver resolver = new Dstu3FhirModelResolver();
+        
+        Patient p = new Patient();
+
+        Object result =resolver.resolvePath(p, "notapath");
+        assertNull(result);
     }
 }

--- a/cql-engine-fhir/src/test/java/org/opencds/cqf/cql/model/TestDstu3ModelResolver.java
+++ b/cql-engine-fhir/src/test/java/org/opencds/cqf/cql/model/TestDstu3ModelResolver.java
@@ -234,7 +234,7 @@ public class TestDstu3ModelResolver {
         
         Patient p = new Patient();
 
-        Object result =resolver.resolvePath(p, "notapath");
+        Object result = resolver.resolvePath(p, "notapath");
         assertNull(result);
     }
 }

--- a/cql-engine-fhir/src/test/java/org/opencds/cqf/cql/model/TestR4ModelResolver.java
+++ b/cql-engine-fhir/src/test/java/org/opencds/cqf/cql/model/TestR4ModelResolver.java
@@ -16,6 +16,7 @@ import org.hl7.elm_modelinfo.r1.ClassInfo;
 import org.hl7.elm_modelinfo.r1.TypeInfo;
 import org.hl7.fhir.r4.model.Composition;
 import org.hl7.fhir.r4.model.Enumeration;
+import org.hl7.fhir.r4.model.Patient;
 import org.hl7.fhir.r4.model.Enumerations.*;
 import org.opencds.cqf.cql.exception.UnknownType;
 
@@ -243,5 +244,15 @@ public class TestR4ModelResolver {
         path = (String)resolver.getContextPath("Patient", "Encounter");
         assertNotNull(path);
         assertTrue(path.equals("subject"));
+    }
+
+    @Test 
+    public void resolveMissingPropertyReturnsNull() {
+        ModelResolver resolver = new R4FhirModelResolver();
+        
+        Patient p = new Patient();
+
+        Object result =resolver.resolvePath(p, "notapath");
+        assertNull(result);
     }
 }

--- a/cql-engine-fhir/src/test/java/org/opencds/cqf/cql/model/TestR4ModelResolver.java
+++ b/cql-engine-fhir/src/test/java/org/opencds/cqf/cql/model/TestR4ModelResolver.java
@@ -252,7 +252,7 @@ public class TestR4ModelResolver {
         
         Patient p = new Patient();
 
-        Object result =resolver.resolvePath(p, "notapath");
+        Object result = resolver.resolvePath(p, "notapath");
         assertNull(result);
     }
 }

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/data/SystemDataProvider.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/data/SystemDataProvider.java
@@ -47,7 +47,7 @@ public class SystemDataProvider implements DataProvider {
         try {
             accessor = clazz.getMethod(accessorMethodName);
         } catch (NoSuchMethodException e) {
-            throw new IllegalArgumentException(String.format("Could not determine accessor function for property %s of type %s", path, clazz.getSimpleName()));
+            return null;
         }
         return accessor;
     }
@@ -85,6 +85,10 @@ public class SystemDataProvider implements DataProvider {
 
         Class<? extends Object> clazz = target.getClass();
         Method accessor = getReadAccessor(clazz, path);
+        if (accessor == null) {
+            return null;
+        }
+        
         try {
             return accessor.invoke(target);
         } catch (InvocationTargetException e) {

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/model/ModelResolver.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/model/ModelResolver.java
@@ -6,6 +6,7 @@ public interface ModelResolver {
 
     void setPackageName(String packageName);
 
+    // Expected to return null whenever a path doesn't exist on the target.
     Object resolvePath(Object target, String path);
 
     Object getContextPath(String contextType, String targetType);

--- a/cql-engine/src/test/java/org/opencds/cqf/cql/data/SystemDataProviderTest.java
+++ b/cql-engine/src/test/java/org/opencds/cqf/cql/data/SystemDataProviderTest.java
@@ -1,0 +1,20 @@
+package org.opencds.cqf.cql.data;
+
+import org.opencds.cqf.cql.data.SystemDataProvider;
+import org.opencds.cqf.cql.runtime.*;
+import org.testng.annotations.Test;
+
+import static org.junit.Assert.assertNull;
+
+public class SystemDataProviderTest {
+
+    @Test
+    public void resolveMissingPropertyReturnsNull() {
+        SystemDataProvider provider = new SystemDataProvider();
+        
+        Date date = new Date(2019, 01, 01);
+
+        Object result = provider.resolvePath(date, "notapath");
+        assertNull(result);
+    }
+}


### PR DESCRIPTION
* Changes the FHIR and System resolvers / data providers to return null when accessing a non-existent property
* Tests for same
* Resolves cqframework/clinical_quality_language#1012 