### PR TITLE
Feature fix warnings

### DIFF
--- a/cql-engine/pom.xml
+++ b/cql-engine/pom.xml
@@ -63,6 +63,7 @@
                         <arg>-npa</arg>
                         <arg>-XautoInheritance</arg>
                         <arg>-XautoInheritance-xmlTypesExtend=org.opencds.cqf.cql.elm.execution.Executable</arg>
+                        <arg>-Xannotate</arg>
                     </args>
                     <plugins>
                         <plugin>
@@ -73,7 +74,12 @@
                         <plugin>
                             <groupId>org.jvnet.jaxb2_commons</groupId>
                             <artifactId>jaxb2-basics</artifactId>
-                            <version>0.9.4</version>
+                            <version>0.12.0</version>
+                        </plugin>
+                        <plugin>
+                            <groupId>org.jvnet.jaxb2_commons</groupId>
+                            <artifactId>jaxb2-basics-annotate</artifactId>
+                            <version>1.1.0</version>
                         </plugin>
                     </plugins>
                     <generateDirectory>src/generated/java</generateDirectory>

--- a/cql-engine/src/main/resources/cql-lm/schema/elm/binding.xjb
+++ b/cql-engine/src/main/resources/cql-lm/schema/elm/binding.xjb
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<jaxb:bindings
+    xmlns:jaxb="http://java.sun.com/xml/ns/jaxb" xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:xjc="http://java.sun.com/xml/ns/jaxb/xjc"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:annox="http://annox.dev.java.net"
+    xsi:schemaLocation="http://java.sun.com/xml/ns/jaxb http://java.sun.com/xml/ns/jaxb/bindingschema_2_0.xsd"
+    jaxb:extensionBindingPrefixes="xjc annox"
+    version="2.1">
+    <jaxb:bindings schemaLocation="library.xsd" node="//xs:complexType" multiple="true" >
+        <annox:annotateClass >@java.lang.SuppressWarnings("all")</annox:annotateClass>
+    </jaxb:bindings>
+    <jaxb:bindings schemaLocation="expression.xsd" node="//xs:complexType" multiple="true" >
+        <annox:annotateClass >@java.lang.SuppressWarnings("all")</annox:annotateClass>
+    </jaxb:bindings>
+     <jaxb:bindings schemaLocation="clinicalexpression.xsd" node="//xs:complexType" multiple="true" >
+        <annox:annotateClass >@java.lang.SuppressWarnings("all")</annox:annotateClass>
+    </jaxb:bindings>
+</jaxb:bindings>

--- a/cql-engine/src/test/java/org/opencds/cqf/cql/execution/CqlExecutionTestBase.java
+++ b/cql-engine/src/test/java/org/opencds/cqf/cql/execution/CqlExecutionTestBase.java
@@ -24,7 +24,7 @@ import java.util.Map;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-public abstract class CqlExecutionTestBase<T> {
+public abstract class CqlExecutionTestBase {
     static Map<String, Library> libraries = new HashMap<>();
     Library library = null;
     private File xmlFile = null;


### PR DESCRIPTION
* Remove the generic type from the test base class
* Update jaxb2 plugins
* Add suppress warnings to generated classes
* Partially resolves cqframework/clinical_quality_language#985 

This fixes approximately 5500 warnings