### PR TITLE
Organize Usings, fix spelling

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,9 +12,12 @@
     ],
     "java.test.defaultConfig": "Profiling",
     "cSpell.words": [
+        "BACKBONEELEMENT",
         "Codeable",
+        "DOMAINRESOURCE",
         "Dstu",
         "Fhir",
+        "SNOMED",
         "hapi",
         "ucum"
     ]

--- a/cql-engine-fhir/src/main/java/org/opencds/cqf/cql/model/Dstu2FhirModelResolver.java
+++ b/cql-engine-fhir/src/main/java/org/opencds/cqf/cql/model/Dstu2FhirModelResolver.java
@@ -1,13 +1,21 @@
 package org.opencds.cqf.cql.model;
 
-import ca.uhn.fhir.context.FhirContext;
-import ca.uhn.fhir.context.FhirVersionEnum;
-
 import java.lang.reflect.Field;
 import java.util.Calendar;
 
-import org.hl7.fhir.dstu2.model.*;
 import org.hl7.fhir.dstu2.model.AnnotatedUuidType;
+import org.hl7.fhir.dstu2.model.Base;
+import org.hl7.fhir.dstu2.model.BaseDateTimeType;
+import org.hl7.fhir.dstu2.model.EnumFactory;
+import org.hl7.fhir.dstu2.model.Enumeration;
+import org.hl7.fhir.dstu2.model.Enumerations;
+import org.hl7.fhir.dstu2.model.IdType;
+import org.hl7.fhir.dstu2.model.Resource;
+import org.hl7.fhir.dstu2.model.SimpleQuantity;
+import org.hl7.fhir.dstu2.model.TimeType;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.context.FhirVersionEnum;
 
 public class Dstu2FhirModelResolver extends  FhirModelResolver<Base, BaseDateTimeType, TimeType, SimpleQuantity, IdType, Resource, Enumeration<?>, EnumFactory<?>> {
 

--- a/cql-engine-fhir/src/main/java/org/opencds/cqf/cql/model/Dstu3FhirModelResolver.java
+++ b/cql-engine-fhir/src/main/java/org/opencds/cqf/cql/model/Dstu3FhirModelResolver.java
@@ -2,7 +2,16 @@ package org.opencds.cqf.cql.model;
 
 import java.util.Calendar;
 
-import org.hl7.fhir.dstu3.model.*;
+import org.hl7.fhir.dstu3.model.AnnotatedUuidType;
+import org.hl7.fhir.dstu3.model.Base;
+import org.hl7.fhir.dstu3.model.BaseDateTimeType;
+import org.hl7.fhir.dstu3.model.EnumFactory;
+import org.hl7.fhir.dstu3.model.Enumeration;
+import org.hl7.fhir.dstu3.model.Enumerations;
+import org.hl7.fhir.dstu3.model.IdType;
+import org.hl7.fhir.dstu3.model.Resource;
+import org.hl7.fhir.dstu3.model.SimpleQuantity;
+import org.hl7.fhir.dstu3.model.TimeType;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;

--- a/cql-engine-fhir/src/main/java/org/opencds/cqf/cql/model/R4FhirModelResolver.java
+++ b/cql-engine-fhir/src/main/java/org/opencds/cqf/cql/model/R4FhirModelResolver.java
@@ -2,7 +2,16 @@ package org.opencds.cqf.cql.model;
 
 import java.util.Calendar;
 
-import org.hl7.fhir.r4.model.*;
+import org.hl7.fhir.r4.model.AnnotatedUuidType;
+import org.hl7.fhir.r4.model.Base;
+import org.hl7.fhir.r4.model.BaseDateTimeType;
+import org.hl7.fhir.r4.model.EnumFactory;
+import org.hl7.fhir.r4.model.Enumeration;
+import org.hl7.fhir.r4.model.Enumerations;
+import org.hl7.fhir.r4.model.IdType;
+import org.hl7.fhir.r4.model.Resource;
+import org.hl7.fhir.r4.model.SimpleQuantity;
+import org.hl7.fhir.r4.model.TimeType;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;

--- a/cql-engine-fhir/src/main/java/org/opencds/cqf/cql/retrieve/FhirBundleCursor.java
+++ b/cql-engine-fhir/src/main/java/org/opencds/cqf/cql/retrieve/FhirBundleCursor.java
@@ -1,14 +1,14 @@
 package org.opencds.cqf.cql.retrieve;
 
-import ca.uhn.fhir.rest.client.api.IGenericClient;
-import ca.uhn.fhir.util.BundleUtil;
+import java.util.Iterator;
+import java.util.List;
 
 import org.hl7.fhir.instance.model.api.IBaseBundle;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.opencds.cqf.cql.exception.UnknownElement;
 
-import java.util.Iterator;
-import java.util.List;
+import ca.uhn.fhir.rest.client.api.IGenericClient;
+import ca.uhn.fhir.util.BundleUtil;
 
 public class FhirBundleCursor implements Iterable<Object> {
 

--- a/cql-engine-fhir/src/main/java/org/opencds/cqf/cql/retrieve/FileBasedFhirRetrieveProvider.java
+++ b/cql-engine-fhir/src/main/java/org/opencds/cqf/cql/retrieve/FileBasedFhirRetrieveProvider.java
@@ -10,17 +10,15 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.opencds.cqf.cql.util.CodeUtil;
-
 import org.hl7.fhir.instance.model.api.IPrimitiveType;
 import org.opencds.cqf.cql.exception.DataProviderException;
 import org.opencds.cqf.cql.exception.UnknownPath;
 import org.opencds.cqf.cql.model.ModelResolver;
-import org.opencds.cqf.cql.retrieve.RetrieveProvider;
 import org.opencds.cqf.cql.runtime.Code;
 import org.opencds.cqf.cql.runtime.Interval;
 import org.opencds.cqf.cql.terminology.TerminologyProvider;
 import org.opencds.cqf.cql.terminology.ValueSetInfo;
+import org.opencds.cqf.cql.util.CodeUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/cql-engine-fhir/src/main/java/org/opencds/cqf/cql/retrieve/FileBasedFhirTerminologyProvider.java
+++ b/cql-engine-fhir/src/main/java/org/opencds/cqf/cql/retrieve/FileBasedFhirTerminologyProvider.java
@@ -10,14 +10,13 @@ import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.opencds.cqf.cql.Helpers;
-
 import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.opencds.cqf.cql.Helpers;
 import org.opencds.cqf.cql.runtime.Code;
-import org.opencds.cqf.cql.util.ValueSetUtil;
 import org.opencds.cqf.cql.terminology.CodeSystemInfo;
 import org.opencds.cqf.cql.terminology.TerminologyProvider;
 import org.opencds.cqf.cql.terminology.ValueSetInfo;
+import org.opencds.cqf.cql.util.ValueSetUtil;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.parser.IParser;

--- a/cql-engine-fhir/src/main/java/org/opencds/cqf/cql/searchparam/SearchParameterMap.java
+++ b/cql-engine-fhir/src/main/java/org/opencds/cqf/cql/searchparam/SearchParameterMap.java
@@ -1,26 +1,40 @@
 package org.opencds.cqf.cql.searchparam;
 
-import ca.uhn.fhir.context.FhirContext;
-import ca.uhn.fhir.model.api.IQueryParameterAnd;
-import ca.uhn.fhir.model.api.IQueryParameterOr;
-import ca.uhn.fhir.model.api.IQueryParameterType;
-import ca.uhn.fhir.model.api.Include;
-import ca.uhn.fhir.rest.api.*;
-import ca.uhn.fhir.rest.param.DateParam;
-import ca.uhn.fhir.rest.param.DateRangeParam;
-import ca.uhn.fhir.rest.param.QuantityParam;
-import ca.uhn.fhir.util.ObjectUtil;
-import ca.uhn.fhir.util.UrlUtil;
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
-import java.io.Serializable;
-import java.util.*;
-
-import static org.apache.commons.lang3.StringUtils.isBlank;
-import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.model.api.IQueryParameterAnd;
+import ca.uhn.fhir.model.api.IQueryParameterOr;
+import ca.uhn.fhir.model.api.IQueryParameterType;
+import ca.uhn.fhir.model.api.Include;
+import ca.uhn.fhir.rest.api.Constants;
+import ca.uhn.fhir.rest.api.SearchTotalModeEnum;
+import ca.uhn.fhir.rest.api.SortOrderEnum;
+import ca.uhn.fhir.rest.api.SortSpec;
+import ca.uhn.fhir.rest.api.SummaryEnum;
+import ca.uhn.fhir.rest.param.DateParam;
+import ca.uhn.fhir.rest.param.DateRangeParam;
+import ca.uhn.fhir.rest.param.QuantityParam;
+import ca.uhn.fhir.util.ObjectUtil;
+import ca.uhn.fhir.util.UrlUtil;
 
 // This class was copied from package ca.uhn.fhir.jpa.searchparam.SearchParameterMap
 // It included many unnecessary HAPI FHIR server dependencies.

--- a/cql-engine-fhir/src/main/java/org/opencds/cqf/cql/searchparam/SearchParameterResolver.java
+++ b/cql-engine-fhir/src/main/java/org/opencds/cqf/cql/searchparam/SearchParameterResolver.java
@@ -9,7 +9,12 @@ import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.RuntimeSearchParam;
 import ca.uhn.fhir.model.api.IQueryParameterType;
 import ca.uhn.fhir.rest.api.RestSearchParameterTypeEnum;
-import ca.uhn.fhir.rest.param.*;
+import ca.uhn.fhir.rest.param.NumberParam;
+import ca.uhn.fhir.rest.param.QuantityParam;
+import ca.uhn.fhir.rest.param.ReferenceParam;
+import ca.uhn.fhir.rest.param.StringParam;
+import ca.uhn.fhir.rest.param.TokenParam;
+import ca.uhn.fhir.rest.param.UriParam;
 
 public class SearchParameterResolver {
 

--- a/cql-engine-fhir/src/main/java/org/opencds/cqf/cql/terminology/fhir/Dstu3FhirTerminologyProvider.java
+++ b/cql-engine-fhir/src/main/java/org/opencds/cqf/cql/terminology/fhir/Dstu3FhirTerminologyProvider.java
@@ -1,20 +1,29 @@
 package org.opencds.cqf.cql.terminology.fhir;
 
-import ca.uhn.fhir.rest.client.api.IClientInterceptor;
-import ca.uhn.fhir.rest.client.api.IGenericClient;
-import org.hl7.fhir.dstu3.model.*;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+
+import org.hl7.fhir.dstu3.model.BooleanType;
+import org.hl7.fhir.dstu3.model.Bundle;
+import org.hl7.fhir.dstu3.model.CodeSystem;
+import org.hl7.fhir.dstu3.model.CodeType;
+import org.hl7.fhir.dstu3.model.IdType;
+import org.hl7.fhir.dstu3.model.Parameters;
+import org.hl7.fhir.dstu3.model.StringType;
+import org.hl7.fhir.dstu3.model.UriType;
+import org.hl7.fhir.dstu3.model.ValueSet;
 import org.opencds.cqf.cql.runtime.Code;
 import org.opencds.cqf.cql.terminology.CodeSystemInfo;
 import org.opencds.cqf.cql.terminology.TerminologyProvider;
 import org.opencds.cqf.cql.terminology.ValueSetInfo;
-import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
 
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.ArrayList;
+import ca.uhn.fhir.rest.client.api.IClientInterceptor;
+import ca.uhn.fhir.rest.client.api.IGenericClient;
+import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
 
 public class Dstu3FhirTerminologyProvider implements TerminologyProvider {
 

--- a/cql-engine-fhir/src/main/java/org/opencds/cqf/cql/terminology/fhir/HeaderInjectionInterceptor.java
+++ b/cql-engine-fhir/src/main/java/org/opencds/cqf/cql/terminology/fhir/HeaderInjectionInterceptor.java
@@ -7,13 +7,13 @@
 
 package org.opencds.cqf.cql.terminology.fhir;
 
-import ca.uhn.fhir.rest.client.api.IClientInterceptor;
-import ca.uhn.fhir.rest.client.api.IHttpRequest;
-import ca.uhn.fhir.rest.client.api.IHttpResponse;
-
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+
+import ca.uhn.fhir.rest.client.api.IClientInterceptor;
+import ca.uhn.fhir.rest.client.api.IHttpRequest;
+import ca.uhn.fhir.rest.client.api.IHttpResponse;
 
 public class HeaderInjectionInterceptor implements IClientInterceptor {
 

--- a/cql-engine-fhir/src/main/java/org/opencds/cqf/cql/terminology/fhir/R4FhirTerminologyProvider.java
+++ b/cql-engine-fhir/src/main/java/org/opencds/cqf/cql/terminology/fhir/R4FhirTerminologyProvider.java
@@ -1,23 +1,29 @@
 package org.opencds.cqf.cql.terminology.fhir;
 
-import ca.uhn.fhir.rest.client.api.IClientInterceptor;
-import ca.uhn.fhir.rest.client.api.IGenericClient;
-import ca.uhn.fhir.rest.client.api.ServerValidationModeEnum;
-import ca.uhn.fhir.rest.client.interceptor.BasicAuthInterceptor;
-import org.hl7.fhir.r4.model.*;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+
+import org.hl7.fhir.r4.model.BooleanType;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.CodeSystem;
+import org.hl7.fhir.r4.model.CodeType;
+import org.hl7.fhir.r4.model.IdType;
+import org.hl7.fhir.r4.model.Parameters;
+import org.hl7.fhir.r4.model.StringType;
+import org.hl7.fhir.r4.model.UriType;
+import org.hl7.fhir.r4.model.ValueSet;
 import org.opencds.cqf.cql.runtime.Code;
 import org.opencds.cqf.cql.terminology.CodeSystemInfo;
 import org.opencds.cqf.cql.terminology.TerminologyProvider;
 import org.opencds.cqf.cql.terminology.ValueSetInfo;
-import ca.uhn.fhir.context.FhirContext;
-import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
 
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.ArrayList;
+import ca.uhn.fhir.rest.client.api.IClientInterceptor;
+import ca.uhn.fhir.rest.client.api.IGenericClient;
+import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
 
 public class R4FhirTerminologyProvider implements TerminologyProvider {
 

--- a/cql-engine-fhir/src/main/java/org/opencds/cqf/cql/util/CodeUtil.java
+++ b/cql-engine-fhir/src/main/java/org/opencds/cqf/cql/util/CodeUtil.java
@@ -1,16 +1,17 @@
 package org.opencds.cqf.cql.util;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hl7.fhir.instance.model.api.IBase;
+import org.hl7.fhir.instance.model.api.IPrimitiveType;
+import org.opencds.cqf.cql.runtime.Code;
+
 import ca.uhn.fhir.context.BaseRuntimeChildDefinition;
 import ca.uhn.fhir.context.BaseRuntimeChildDefinition.IAccessor;
 import ca.uhn.fhir.context.BaseRuntimeElementDefinition;
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.RuntimeCompositeDatatypeDefinition;
-import org.hl7.fhir.instance.model.api.IBase;
-import org.hl7.fhir.instance.model.api.IPrimitiveType;
-import org.opencds.cqf.cql.runtime.Code;
-
-import java.util.ArrayList;
-import java.util.List;
 
 public class CodeUtil {
 

--- a/cql-engine-fhir/src/main/java/org/opencds/cqf/cql/util/ValueSetUtil.java
+++ b/cql-engine-fhir/src/main/java/org/opencds/cqf/cql/util/ValueSetUtil.java
@@ -1,14 +1,19 @@
 package org.opencds.cqf.cql.util;
 
-import ca.uhn.fhir.context.*;
-import ca.uhn.fhir.context.BaseRuntimeChildDefinition.IAccessor;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.instance.model.api.IPrimitiveType;
 import org.opencds.cqf.cql.runtime.Code;
 
-import java.util.ArrayList;
-import java.util.List;
+import ca.uhn.fhir.context.BaseRuntimeChildDefinition;
+import ca.uhn.fhir.context.BaseRuntimeChildDefinition.IAccessor;
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.context.RuntimeChildResourceBlockDefinition;
+import ca.uhn.fhir.context.RuntimeResourceBlockDefinition;
+import ca.uhn.fhir.context.RuntimeResourceDefinition;
 
 public class ValueSetUtil {
 

--- a/cql-engine-fhir/src/test/java/org/hl7/fhirpath/TestFhirPath.java
+++ b/cql-engine-fhir/src/test/java/org/hl7/fhirpath/TestFhirPath.java
@@ -1,29 +1,46 @@
 package org.hl7.fhirpath;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
 import java.io.BufferedReader;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.IOException;
 import java.io.StringReader;
 import java.time.Instant;
 import java.time.ZoneOffset;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.Iterator;
+import java.util.List;
+import java.util.TimeZone;
 
 import javax.xml.bind.JAXB;
 import javax.xml.bind.JAXBException;
 
-import ca.uhn.fhir.context.FhirContext;
-
-import org.cqframework.cql.cql2elm.*;
-import org.cqframework.cql.elm.execution.ExpressionDef;
+import org.cqframework.cql.cql2elm.CqlTranslator;
+import org.cqframework.cql.cql2elm.CqlTranslatorException;
+import org.cqframework.cql.cql2elm.FhirLibrarySourceProvider;
+import org.cqframework.cql.cql2elm.LibraryManager;
+import org.cqframework.cql.cql2elm.ModelManager;
 import org.cqframework.cql.elm.execution.Library;
 import org.cqframework.cql.elm.tracking.TrackBack;
 import org.fhir.ucum.UcumEssenceService;
 import org.fhir.ucum.UcumException;
 import org.fhir.ucum.UcumService;
-import org.hl7.fhir.dstu3.model.*;
-import org.hl7.fhir.r4.model.Resource;
+import org.hl7.fhir.dstu3.model.BaseDateTimeType;
+import org.hl7.fhir.dstu3.model.BooleanType;
+import org.hl7.fhir.dstu3.model.Coding;
+import org.hl7.fhir.dstu3.model.DateType;
+import org.hl7.fhir.dstu3.model.DecimalType;
 import org.hl7.fhir.dstu3.model.Enumeration;
+import org.hl7.fhir.dstu3.model.IntegerType;
+import org.hl7.fhir.dstu3.model.Quantity;
+import org.hl7.fhir.dstu3.model.StringType;
+import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhirpath.tests.Group;
 import org.hl7.fhirpath.tests.Tests;
 import org.opencds.cqf.cql.data.CompositeDataProvider;
@@ -40,8 +57,7 @@ import org.opencds.cqf.cql.runtime.DateTime;
 import org.opencds.cqf.cql.searchparam.SearchParameterResolver;
 import org.testng.annotations.Test;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import ca.uhn.fhir.context.FhirContext;
 
 public class TestFhirPath {
 

--- a/cql-engine-fhir/src/test/java/org/hl7/fhirpath/TestLibraryLoader.java
+++ b/cql-engine-fhir/src/test/java/org/hl7/fhirpath/TestLibraryLoader.java
@@ -1,27 +1,28 @@
 package org.hl7.fhirpath;
 
-import org.cqframework.cql.cql2elm.CqlTranslator;
-import org.cqframework.cql.cql2elm.CqlTranslatorException;
-import org.cqframework.cql.cql2elm.LibraryManager;
-import org.cqframework.cql.cql2elm.CqlTranslatorException.ErrorSeverity;
-import org.cqframework.cql.cql2elm.LibraryBuilder.SignatureLevel;
-import org.cqframework.cql.elm.execution.Library;
-import org.cqframework.cql.elm.execution.VersionedIdentifier;
-import org.hl7.elm.r1.ObjectFactory;
-import org.opencds.cqf.cql.execution.CqlLibraryReader;
-import org.opencds.cqf.cql.execution.LibraryLoader;
-
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Marshaller;
 import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
-import org.hl7.cql_annotations.r1.Annotation;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Marshaller;
+
+import org.cqframework.cql.cql2elm.CqlTranslator;
+import org.cqframework.cql.cql2elm.CqlTranslatorException;
+import org.cqframework.cql.cql2elm.CqlTranslatorException.ErrorSeverity;
+import org.cqframework.cql.cql2elm.LibraryBuilder.SignatureLevel;
+import org.cqframework.cql.cql2elm.LibraryManager;
+import org.cqframework.cql.elm.execution.Library;
+import org.cqframework.cql.elm.execution.VersionedIdentifier;
+import org.hl7.cql_annotations.r1.Annotation;
+import org.hl7.elm.r1.ObjectFactory;
+import org.opencds.cqf.cql.execution.CqlLibraryReader;
+import org.opencds.cqf.cql.execution.LibraryLoader;
 
 public class TestLibraryLoader implements LibraryLoader {
 

--- a/cql-engine-fhir/src/test/java/org/hl7/fhirpath/TestLibrarySourceProvider.java
+++ b/cql-engine-fhir/src/test/java/org/hl7/fhirpath/TestLibrarySourceProvider.java
@@ -1,9 +1,9 @@
 package org.hl7.fhirpath;
 
+import java.io.InputStream;
+
 import org.cqframework.cql.cql2elm.LibrarySourceProvider;
 import org.hl7.elm.r1.VersionedIdentifier;
-
-import java.io.InputStream;
 
 public class TestLibrarySourceProvider implements LibrarySourceProvider {
     @Override

--- a/cql-engine-fhir/src/test/java/org/hl7/fhirpath/tests/Expression.java
+++ b/cql-engine-fhir/src/test/java/org/hl7/fhirpath/tests/Expression.java
@@ -13,6 +13,7 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.XmlValue;
+
 import org.jvnet.jaxb2_commons.lang.Equals;
 import org.jvnet.jaxb2_commons.lang.EqualsStrategy;
 import org.jvnet.jaxb2_commons.lang.HashCode;

--- a/cql-engine-fhir/src/test/java/org/hl7/fhirpath/tests/Group.java
+++ b/cql-engine-fhir/src/test/java/org/hl7/fhirpath/tests/Group.java
@@ -11,11 +11,13 @@ package org.hl7.fhirpath.tests;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
+
 import org.jvnet.jaxb2_commons.lang.Equals;
 import org.jvnet.jaxb2_commons.lang.EqualsStrategy;
 import org.jvnet.jaxb2_commons.lang.HashCode;

--- a/cql-engine-fhir/src/test/java/org/hl7/fhirpath/tests/ObjectFactory.java
+++ b/cql-engine-fhir/src/test/java/org/hl7/fhirpath/tests/ObjectFactory.java
@@ -18,7 +18,7 @@ import javax.xml.namespace.QName;
  * This object contains factory methods for each 
  * Java content interface and Java element interface 
  * generated in the org.hl7.fhirpath.tests package. 
- * <p>An ObjectFactory allows you to programatically 
+ * <p>An ObjectFactory allows you to programmatically 
  * construct new instances of the Java representation 
  * for XML content. The Java representation of XML 
  * content can consist of schema derived interfaces 

--- a/cql-engine-fhir/src/test/java/org/hl7/fhirpath/tests/Output.java
+++ b/cql-engine-fhir/src/test/java/org/hl7/fhirpath/tests/Output.java
@@ -13,6 +13,7 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.XmlValue;
+
 import org.jvnet.jaxb2_commons.lang.Equals;
 import org.jvnet.jaxb2_commons.lang.EqualsStrategy;
 import org.jvnet.jaxb2_commons.lang.HashCode;

--- a/cql-engine-fhir/src/test/java/org/hl7/fhirpath/tests/Test.java
+++ b/cql-engine-fhir/src/test/java/org/hl7/fhirpath/tests/Test.java
@@ -11,11 +11,13 @@ package org.hl7.fhirpath.tests;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
+
 import org.jvnet.jaxb2_commons.lang.Equals;
 import org.jvnet.jaxb2_commons.lang.EqualsStrategy;
 import org.jvnet.jaxb2_commons.lang.HashCode;

--- a/cql-engine-fhir/src/test/java/org/hl7/fhirpath/tests/Tests.java
+++ b/cql-engine-fhir/src/test/java/org/hl7/fhirpath/tests/Tests.java
@@ -11,10 +11,12 @@ package org.hl7.fhirpath.tests;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
+
 import org.jvnet.jaxb2_commons.lang.Equals;
 import org.jvnet.jaxb2_commons.lang.EqualsStrategy;
 import org.jvnet.jaxb2_commons.lang.HashCode;

--- a/cql-engine-fhir/src/test/java/org/opencds/cqf/cql/data/fhir/FhirExecutionTestBase.java
+++ b/cql-engine-fhir/src/test/java/org/opencds/cqf/cql/data/fhir/FhirExecutionTestBase.java
@@ -1,5 +1,18 @@
 package org.opencds.cqf.cql.data.fhir;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.net.URLDecoder;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.xml.bind.JAXBException;
+
 import org.cqframework.cql.cql2elm.CqlTranslator;
 import org.cqframework.cql.cql2elm.CqlTranslatorException;
 import org.cqframework.cql.cql2elm.LibraryManager;
@@ -11,25 +24,14 @@ import org.fhir.ucum.UcumException;
 import org.fhir.ucum.UcumService;
 import org.opencds.cqf.cql.data.CompositeDataProvider;
 import org.opencds.cqf.cql.execution.CqlLibraryReader;
-import org.opencds.cqf.cql.model.*;
-import org.opencds.cqf.cql.retrieve.*;
+import org.opencds.cqf.cql.model.Dstu2FhirModelResolver;
+import org.opencds.cqf.cql.model.Dstu3FhirModelResolver;
+import org.opencds.cqf.cql.retrieve.RestFhirRetrieveProvider;
 import org.opencds.cqf.cql.searchparam.SearchParameterResolver;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 
 import ca.uhn.fhir.context.FhirContext;
-
-import javax.xml.bind.JAXBException;
-import java.io.File;
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.net.URLDecoder;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Map;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
 
 public abstract class FhirExecutionTestBase {
 	static Map<String, Library> libraries = new HashMap<>();

--- a/cql-engine-fhir/src/test/java/org/opencds/cqf/cql/data/fhir/TestCodeRef.java
+++ b/cql-engine-fhir/src/test/java/org/opencds/cqf/cql/data/fhir/TestCodeRef.java
@@ -1,11 +1,12 @@
 package org.opencds.cqf.cql.data.fhir;
 
-import ca.uhn.fhir.context.FhirContext;
-import ca.uhn.fhir.rest.client.api.IGenericClient;
+import static org.testng.AssertJUnit.assertTrue;
+
 import org.opencds.cqf.cql.execution.Context;
 import org.opencds.cqf.cql.terminology.fhir.Dstu3FhirTerminologyProvider;
 
-import static org.testng.AssertJUnit.assertTrue;
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.rest.client.api.IGenericClient;
 
 public class TestCodeRef extends FhirExecutionTestBase {
 

--- a/cql-engine-fhir/src/test/java/org/opencds/cqf/cql/data/fhir/TestFhirDataProviderDstu2.java
+++ b/cql-engine-fhir/src/test/java/org/opencds/cqf/cql/data/fhir/TestFhirDataProviderDstu2.java
@@ -1,14 +1,12 @@
 package org.opencds.cqf.cql.data.fhir;
 
+import static org.testng.Assert.assertTrue;
+
+import org.hl7.fhir.dstu2.model.Encounter;
 import org.opencds.cqf.cql.execution.Context;
 import org.opencds.cqf.cql.retrieve.FhirBundleCursor;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
-
-import static org.testng.Assert.assertTrue;
-
-import org.hl7.fhir.dstu2.model.Encounter;
 
 public class TestFhirDataProviderDstu2 extends FhirExecutionTestBase {
 

--- a/cql-engine-fhir/src/test/java/org/opencds/cqf/cql/data/fhir/TestFhirDataProviderDstu3.java
+++ b/cql-engine-fhir/src/test/java/org/opencds/cqf/cql/data/fhir/TestFhirDataProviderDstu3.java
@@ -1,21 +1,25 @@
 package org.opencds.cqf.cql.data.fhir;
 
-import ca.uhn.fhir.context.FhirContext;
-import ca.uhn.fhir.rest.client.api.IGenericClient;
-import org.hl7.fhir.dstu3.model.*;
-import org.opencds.cqf.cql.data.CompositeDataProvider;
-import org.opencds.cqf.cql.execution.Context;
-import org.opencds.cqf.cql.terminology.fhir.Dstu3FhirTerminologyProvider;
-import org.opencds.cqf.cql.model.*;
-import org.opencds.cqf.cql.retrieve.*;
-import org.opencds.cqf.cql.searchparam.SearchParameterResolver;
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import static org.testng.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.testng.Assert.assertTrue;
+import org.hl7.fhir.dstu3.model.Bundle;
+import org.hl7.fhir.dstu3.model.ListResource;
+import org.hl7.fhir.dstu3.model.Patient;
+import org.opencds.cqf.cql.data.CompositeDataProvider;
+import org.opencds.cqf.cql.execution.Context;
+import org.opencds.cqf.cql.model.Dstu3FhirModelResolver;
+import org.opencds.cqf.cql.retrieve.FhirBundleCursor;
+import org.opencds.cqf.cql.retrieve.RestFhirRetrieveProvider;
+import org.opencds.cqf.cql.searchparam.SearchParameterResolver;
+import org.opencds.cqf.cql.terminology.fhir.Dstu3FhirTerminologyProvider;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.rest.client.api.IGenericClient;
 
 public class TestFhirDataProviderDstu3 extends FhirExecutionTestBase {
 

--- a/cql-engine-fhir/src/test/java/org/opencds/cqf/cql/data/fhir/TestFhirExecution.java
+++ b/cql-engine-fhir/src/test/java/org/opencds/cqf/cql/data/fhir/TestFhirExecution.java
@@ -1,10 +1,9 @@
 package org.opencds.cqf.cql.data.fhir;
 
+import java.util.List;
+
 import org.opencds.cqf.cql.execution.Context;
 import org.testng.Assert;
-import org.testng.annotations.Test;
-
-import java.util.List;
 
 public class TestFhirExecution extends FhirExecutionTestBase {
 

--- a/cql-engine-fhir/src/test/java/org/opencds/cqf/cql/data/fhir/TestFhirLibrary.java
+++ b/cql-engine-fhir/src/test/java/org/opencds/cqf/cql/data/fhir/TestFhirLibrary.java
@@ -1,5 +1,15 @@
 package org.opencds.cqf.cql.data.fhir;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URLDecoder;
+
+import javax.xml.bind.JAXBException;
+
 import org.cqframework.cql.elm.execution.Library;
 import org.hl7.fhir.dstu3.model.Observation;
 import org.hl7.fhir.dstu3.model.RiskAssessment;
@@ -11,15 +21,6 @@ import org.opencds.cqf.cql.retrieve.RestFhirRetrieveProvider;
 import org.opencds.cqf.cql.searchparam.SearchParameterResolver;
 
 import ca.uhn.fhir.context.FhirContext;
-
-import javax.xml.bind.JAXBException;
-import java.io.File;
-import java.io.IOException;
-import java.net.URLDecoder;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
 
 public class TestFhirLibrary {
 

--- a/cql-engine-fhir/src/test/java/org/opencds/cqf/cql/data/fhir/TestLibrarySourceProvider.java
+++ b/cql-engine-fhir/src/test/java/org/opencds/cqf/cql/data/fhir/TestLibrarySourceProvider.java
@@ -1,9 +1,9 @@
 package org.opencds.cqf.cql.data.fhir;
 
+import java.io.InputStream;
+
 import org.cqframework.cql.cql2elm.LibrarySourceProvider;
 import org.hl7.elm.r1.VersionedIdentifier;
-
-import java.io.InputStream;
 
 public class TestLibrarySourceProvider implements LibrarySourceProvider {
     @Override

--- a/cql-engine-fhir/src/test/java/org/opencds/cqf/cql/model/TestDstu2ModelResolver.java
+++ b/cql-engine-fhir/src/test/java/org/opencds/cqf/cql/model/TestDstu2ModelResolver.java
@@ -1,18 +1,32 @@
 package org.opencds.cqf.cql.model;
 
-import org.hl7.fhir.dstu2.model.Enumerations.*;
-import org.hl7.fhir.dstu2.model.Enumerations.ResourceType;
-import org.hl7.fhir.dstu2.model.*;
-
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import org.testng.annotations.Test;
 import static org.testng.AssertJUnit.assertTrue;
+
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.hl7.fhir.dstu2.model.EnumFactory;
+import org.hl7.fhir.dstu2.model.Enumeration;
+import org.hl7.fhir.dstu2.model.Enumerations.AdministrativeGender;
+import org.hl7.fhir.dstu2.model.Enumerations.AgeUnits;
+import org.hl7.fhir.dstu2.model.Enumerations.BindingStrength;
+import org.hl7.fhir.dstu2.model.Enumerations.ConceptMapEquivalence;
+import org.hl7.fhir.dstu2.model.Enumerations.DataAbsentReason;
+import org.hl7.fhir.dstu2.model.Enumerations.DataType;
+import org.hl7.fhir.dstu2.model.Enumerations.DocumentReferenceStatus;
+import org.hl7.fhir.dstu2.model.Enumerations.FHIRDefinedType;
+import org.hl7.fhir.dstu2.model.Enumerations.MessageEvent;
+import org.hl7.fhir.dstu2.model.Enumerations.NoteType;
+import org.hl7.fhir.dstu2.model.Enumerations.RemittanceOutcome;
+import org.hl7.fhir.dstu2.model.Enumerations.ResourceType;
+import org.hl7.fhir.dstu2.model.Enumerations.SearchParamType;
+import org.hl7.fhir.dstu2.model.Enumerations.SpecialValues;
+import org.hl7.fhir.dstu2.model.Patient;
 import org.opencds.cqf.cql.exception.UnknownType;
+import org.testng.annotations.Test;
 
 public class TestDstu2ModelResolver {
 

--- a/cql-engine-fhir/src/test/java/org/opencds/cqf/cql/model/TestDstu3ModelResolver.java
+++ b/cql-engine-fhir/src/test/java/org/opencds/cqf/cql/model/TestDstu3ModelResolver.java
@@ -1,7 +1,5 @@
 package org.opencds.cqf.cql.model;
 
-import org.testng.annotations.Test;
-
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.testng.AssertJUnit.assertTrue;
@@ -15,9 +13,26 @@ import org.hl7.elm.r1.VersionedIdentifier;
 import org.hl7.elm_modelinfo.r1.ClassInfo;
 import org.hl7.elm_modelinfo.r1.TypeInfo;
 import org.hl7.fhir.dstu3.model.Enumeration;
+import org.hl7.fhir.dstu3.model.Enumerations.AbstractType;
+import org.hl7.fhir.dstu3.model.Enumerations.AdministrativeGender;
+import org.hl7.fhir.dstu3.model.Enumerations.AgeUnits;
+import org.hl7.fhir.dstu3.model.Enumerations.BindingStrength;
+import org.hl7.fhir.dstu3.model.Enumerations.ConceptMapEquivalence;
+import org.hl7.fhir.dstu3.model.Enumerations.DataAbsentReason;
+import org.hl7.fhir.dstu3.model.Enumerations.DataType;
+import org.hl7.fhir.dstu3.model.Enumerations.DocumentReferenceStatus;
+import org.hl7.fhir.dstu3.model.Enumerations.FHIRAllTypes;
+import org.hl7.fhir.dstu3.model.Enumerations.FHIRDefinedType;
+import org.hl7.fhir.dstu3.model.Enumerations.MessageEvent;
+import org.hl7.fhir.dstu3.model.Enumerations.NoteType;
+import org.hl7.fhir.dstu3.model.Enumerations.PublicationStatus;
+import org.hl7.fhir.dstu3.model.Enumerations.RemittanceOutcome;
+import org.hl7.fhir.dstu3.model.Enumerations.ResourceType;
+import org.hl7.fhir.dstu3.model.Enumerations.SearchParamType;
+import org.hl7.fhir.dstu3.model.Enumerations.SpecialValues;
 import org.hl7.fhir.dstu3.model.Patient;
-import org.hl7.fhir.dstu3.model.Enumerations.*;
 import org.opencds.cqf.cql.exception.UnknownType;
+import org.testng.annotations.Test;
 
 public class TestDstu3ModelResolver {
 

--- a/cql-engine-fhir/src/test/java/org/opencds/cqf/cql/model/TestR4ModelResolver.java
+++ b/cql-engine-fhir/src/test/java/org/opencds/cqf/cql/model/TestR4ModelResolver.java
@@ -1,7 +1,5 @@
 package org.opencds.cqf.cql.model;
 
-import org.testng.annotations.Test;
-
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.testng.AssertJUnit.assertTrue;
@@ -14,11 +12,32 @@ import org.cqframework.cql.cql2elm.model.Model;
 import org.hl7.elm.r1.VersionedIdentifier;
 import org.hl7.elm_modelinfo.r1.ClassInfo;
 import org.hl7.elm_modelinfo.r1.TypeInfo;
-import org.hl7.fhir.r4.model.Composition;
 import org.hl7.fhir.r4.model.Enumeration;
+import org.hl7.fhir.r4.model.Enumerations.AbstractType;
+import org.hl7.fhir.r4.model.Enumerations.AdministrativeGender;
+import org.hl7.fhir.r4.model.Enumerations.AgeUnits;
+import org.hl7.fhir.r4.model.Enumerations.BindingStrength;
+import org.hl7.fhir.r4.model.Enumerations.ConceptMapEquivalence;
+import org.hl7.fhir.r4.model.Enumerations.DataAbsentReason;
+import org.hl7.fhir.r4.model.Enumerations.DataType;
+import org.hl7.fhir.r4.model.Enumerations.DefinitionResourceType;
+import org.hl7.fhir.r4.model.Enumerations.DocumentReferenceStatus;
+import org.hl7.fhir.r4.model.Enumerations.EventResourceType;
+import org.hl7.fhir.r4.model.Enumerations.FHIRAllTypes;
+import org.hl7.fhir.r4.model.Enumerations.FHIRDefinedType;
+import org.hl7.fhir.r4.model.Enumerations.FHIRVersion;
+import org.hl7.fhir.r4.model.Enumerations.KnowledgeResourceType;
+import org.hl7.fhir.r4.model.Enumerations.MessageEvent;
+import org.hl7.fhir.r4.model.Enumerations.NoteType;
+import org.hl7.fhir.r4.model.Enumerations.PublicationStatus;
+import org.hl7.fhir.r4.model.Enumerations.RemittanceOutcome;
+import org.hl7.fhir.r4.model.Enumerations.RequestResourceType;
+import org.hl7.fhir.r4.model.Enumerations.ResourceType;
+import org.hl7.fhir.r4.model.Enumerations.SearchParamType;
+import org.hl7.fhir.r4.model.Enumerations.SpecialValues;
 import org.hl7.fhir.r4.model.Patient;
-import org.hl7.fhir.r4.model.Enumerations.*;
 import org.opencds.cqf.cql.exception.UnknownType;
+import org.testng.annotations.Test;
 
 public class TestR4ModelResolver {
 
@@ -51,7 +70,7 @@ public class TestR4ModelResolver {
     };
 
     @Test(expectedExceptions = UnknownType.class)
-    public void resolverThrowsExecptionForUnknownType()
+    public void resolverThrowsExceptionForUnknownType()
     {
         ModelResolver resolver = new R4FhirModelResolver();
         resolver.resolveType("ImpossibleTypeThatDoesntExistAndShouldBlowUp");
@@ -125,7 +144,7 @@ public class TestR4ModelResolver {
         resolver.resolveType("vConfidentialityClassification");
     }
 
-    // This tests all the types that are present in the modelinfo
+    // This tests all the types that are present in the ModelInfo
      @Test
     public void resolveModelInfoTests() {
         ModelResolver resolver = new R4FhirModelResolver();
@@ -138,7 +157,7 @@ public class TestR4ModelResolver {
             ClassInfo ci = (ClassInfo)ti;
             if (ci != null) {
                 switch (ci.getBaseType()) {
-                    // Astract classes
+                    // Abstract classes
                     case "FHIR.BackboneElement":
                     case "FHIR.Element": continue;
                 }
@@ -252,7 +271,7 @@ public class TestR4ModelResolver {
         
         Patient p = new Patient();
 
-        Object result = resolver.resolvePath(p, "notapath");
+        Object result = resolver.resolvePath(p, "not-a-path");
         assertNull(result);
     }
 }

--- a/cql-engine-fhir/src/test/java/org/opencds/cqf/cql/searchparam/TestSearchParameterResolver.java
+++ b/cql-engine-fhir/src/test/java/org/opencds/cqf/cql/searchparam/TestSearchParameterResolver.java
@@ -1,6 +1,8 @@
 package org.opencds.cqf.cql.searchparam;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 import org.testng.annotations.Test;
 

--- a/cql-engine-fhir/src/test/java/org/opencds/cqf/cql/util/ValueSetUtilTests.java
+++ b/cql-engine-fhir/src/test/java/org/opencds/cqf/cql/util/ValueSetUtilTests.java
@@ -1,18 +1,19 @@
 package org.opencds.cqf.cql.util;
 
-import ca.uhn.fhir.context.FhirContext;
-import ca.uhn.fhir.parser.IParser;
-import org.hl7.fhir.instance.model.api.IBase;
-import org.hl7.fhir.instance.model.api.IBaseResource;
-import org.opencds.cqf.cql.runtime.Code;
-import org.testng.annotations.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import org.hl7.fhir.instance.model.api.IBase;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.opencds.cqf.cql.runtime.Code;
+import org.testng.annotations.Test;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.parser.IParser;
 
 public class ValueSetUtilTests {
 

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/data/SystemDataProvider.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/data/SystemDataProvider.java
@@ -1,11 +1,18 @@
 package org.opencds.cqf.cql.data;
 
-import org.opencds.cqf.cql.runtime.*;
-
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.math.BigDecimal;
+
+import org.opencds.cqf.cql.runtime.Code;
+import org.opencds.cqf.cql.runtime.CqlType;
+import org.opencds.cqf.cql.runtime.Date;
+import org.opencds.cqf.cql.runtime.DateTime;
+import org.opencds.cqf.cql.runtime.Interval;
+import org.opencds.cqf.cql.runtime.Quantity;
+import org.opencds.cqf.cql.runtime.Time;
+import org.opencds.cqf.cql.runtime.Tuple;
 
 public class SystemDataProvider implements DataProvider {
 

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/AbsEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/AbsEvaluator.java
@@ -1,9 +1,10 @@
 package org.opencds.cqf.cql.elm.execution;
 
+import java.math.BigDecimal;
+
 import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
 import org.opencds.cqf.cql.execution.Context;
 import org.opencds.cqf.cql.runtime.Quantity;
-import java.math.BigDecimal;
 
 /*
 Abs(argument Integer) Integer

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/AddEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/AddEvaluator.java
@@ -1,10 +1,18 @@
 package org.opencds.cqf.cql.elm.execution;
 
+import java.math.BigDecimal;
+
 import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
 import org.opencds.cqf.cql.execution.Context;
-import org.opencds.cqf.cql.runtime.*;
-
-import java.math.BigDecimal;
+import org.opencds.cqf.cql.runtime.BaseTemporal;
+import org.opencds.cqf.cql.runtime.Date;
+import org.opencds.cqf.cql.runtime.DateTime;
+import org.opencds.cqf.cql.runtime.Interval;
+import org.opencds.cqf.cql.runtime.Precision;
+import org.opencds.cqf.cql.runtime.Quantity;
+import org.opencds.cqf.cql.runtime.TemporalHelper;
+import org.opencds.cqf.cql.runtime.Time;
+import org.opencds.cqf.cql.runtime.Value;
 
 /*
 

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/AfterEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/AfterEvaluator.java
@@ -1,8 +1,9 @@
 package org.opencds.cqf.cql.elm.execution;
 
-import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
 import org.opencds.cqf.cql.execution.Context;
-import org.opencds.cqf.cql.runtime.*;
+import org.opencds.cqf.cql.runtime.BaseTemporal;
+import org.opencds.cqf.cql.runtime.Interval;
+import org.opencds.cqf.cql.runtime.Precision;
 
 /*
 

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/AllTrueEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/AllTrueEvaluator.java
@@ -1,9 +1,9 @@
 package org.opencds.cqf.cql.elm.execution;
 
+import java.util.Iterator;
+
 import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
 import org.opencds.cqf.cql.execution.Context;
-
-import java.util.Iterator;
 
 /*
 AllTrue(argument List<Boolean>) Boolean

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/AnyTrueEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/AnyTrueEvaluator.java
@@ -1,9 +1,9 @@
 package org.opencds.cqf.cql.elm.execution;
 
+import java.util.Iterator;
+
 import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
 import org.opencds.cqf.cql.execution.Context;
-
-import java.util.Iterator;
 
 /*
 AnyTrue(argument List<Boolean>) Boolean

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/AvgEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/AvgEvaluator.java
@@ -1,12 +1,10 @@
 package org.opencds.cqf.cql.elm.execution;
 
+import java.math.BigDecimal;
+
 import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
 import org.opencds.cqf.cql.execution.Context;
 import org.opencds.cqf.cql.runtime.Quantity;
-import org.opencds.cqf.cql.runtime.Value;
-
-import java.util.Iterator;
-import java.math.BigDecimal;
 
 /*
 Avg(argument List<Decimal>) Decimal

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/BeforeEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/BeforeEvaluator.java
@@ -1,8 +1,9 @@
 package org.opencds.cqf.cql.elm.execution;
 
-import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
 import org.opencds.cqf.cql.execution.Context;
-import org.opencds.cqf.cql.runtime.*;
+import org.opencds.cqf.cql.runtime.BaseTemporal;
+import org.opencds.cqf.cql.runtime.Interval;
+import org.opencds.cqf.cql.runtime.Precision;
 
 /*
 

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/CaseEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/CaseEvaluator.java
@@ -1,9 +1,8 @@
 package org.opencds.cqf.cql.elm.execution;
 
-import org.opencds.cqf.cql.execution.Context;
 import org.cqframework.cql.elm.execution.CaseItem;
 import org.cqframework.cql.elm.execution.Expression;
-import org.opencds.cqf.cql.runtime.Value;
+import org.opencds.cqf.cql.execution.Context;
 
 /*
 

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/CeilingEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/CeilingEvaluator.java
@@ -1,9 +1,10 @@
 package org.opencds.cqf.cql.elm.execution;
 
+import java.math.BigDecimal;
+
 import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
 import org.opencds.cqf.cql.execution.Context;
 import org.opencds.cqf.cql.runtime.Quantity;
-import java.math.BigDecimal;
 
 /*
 Ceiling(argument Decimal) Integer

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/ChildrenEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/ChildrenEvaluator.java
@@ -1,11 +1,17 @@
 package org.opencds.cqf.cql.elm.execution;
 
-import org.opencds.cqf.cql.execution.Context;
-import org.opencds.cqf.cql.runtime.*;
-
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
+
+import org.opencds.cqf.cql.execution.Context;
+import org.opencds.cqf.cql.runtime.Code;
+import org.opencds.cqf.cql.runtime.Concept;
+import org.opencds.cqf.cql.runtime.DateTime;
+import org.opencds.cqf.cql.runtime.Precision;
+import org.opencds.cqf.cql.runtime.Quantity;
+import org.opencds.cqf.cql.runtime.TemporalHelper;
+import org.opencds.cqf.cql.runtime.Time;
 
 /*
 

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/CoalesceEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/CoalesceEvaluator.java
@@ -1,10 +1,10 @@
 package org.opencds.cqf.cql.elm.execution;
 
-import org.cqframework.cql.elm.execution.Expression;
-import org.opencds.cqf.cql.execution.Context;
-
 import java.util.ArrayList;
 import java.util.List;
+
+import org.cqframework.cql.elm.execution.Expression;
+import org.opencds.cqf.cql.execution.Context;
 
 /*
 Coalesce<T>(argument1 T, argument2 T) T

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/CollapseEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/CollapseEvaluator.java
@@ -1,10 +1,14 @@
 package org.opencds.cqf.cql.elm.execution;
 
-import org.opencds.cqf.cql.execution.Context;
-import org.opencds.cqf.cql.runtime.*;
-
 import java.math.BigDecimal;
-import java.util.*;
+import java.util.Arrays;
+import java.util.List;
+
+import org.opencds.cqf.cql.execution.Context;
+import org.opencds.cqf.cql.runtime.BaseTemporal;
+import org.opencds.cqf.cql.runtime.CqlList;
+import org.opencds.cqf.cql.runtime.Interval;
+import org.opencds.cqf.cql.runtime.Quantity;
 
 /*
 collapse(argument List<Interval<T>>) List<Interval<T>>

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/CombineEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/CombineEvaluator.java
@@ -1,8 +1,9 @@
 package org.opencds.cqf.cql.elm.execution;
 
+import java.util.Iterator;
+
 import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
 import org.opencds.cqf.cql.execution.Context;
-import java.util.Iterator;
 
 /*
 Combine(source List<String>) String

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/ConceptEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/ConceptEvaluator.java
@@ -1,9 +1,9 @@
 package org.opencds.cqf.cql.elm.execution;
 
+import java.util.ArrayList;
+
 import org.opencds.cqf.cql.execution.Context;
 import org.opencds.cqf.cql.runtime.Code;
-
-import java.util.ArrayList;
 
 /*
 structured type Concept

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/CountEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/CountEvaluator.java
@@ -1,8 +1,9 @@
 package org.opencds.cqf.cql.elm.execution;
 
+import java.util.Iterator;
+
 import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
 import org.opencds.cqf.cql.execution.Context;
-import java.util.Iterator;
 
 /*
 Count(argument List<T>) Integer

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/DateTimeEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/DateTimeEvaluator.java
@@ -1,12 +1,12 @@
 package org.opencds.cqf.cql.elm.execution;
 
+import java.math.BigDecimal;
+import java.time.format.DateTimeParseException;
+
 import org.opencds.cqf.cql.exception.InvalidDateTime;
 import org.opencds.cqf.cql.execution.Context;
 import org.opencds.cqf.cql.runtime.DateTime;
 import org.opencds.cqf.cql.runtime.TemporalHelper;
-
-import java.math.BigDecimal;
-import java.time.format.DateTimeParseException;
 
 /*
 simple type DateTime

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/DescendentsEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/DescendentsEvaluator.java
@@ -1,11 +1,11 @@
 package org.opencds.cqf.cql.elm.execution;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.opencds.cqf.cql.execution.Context;
 import org.opencds.cqf.cql.runtime.Interval;
 import org.opencds.cqf.cql.runtime.Tuple;
-
-import java.util.ArrayList;
-import java.util.List;
 
 public class DescendentsEvaluator extends org.cqframework.cql.elm.execution.Descendents {
 

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/DifferenceBetweenEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/DifferenceBetweenEvaluator.java
@@ -2,9 +2,12 @@ package org.opencds.cqf.cql.elm.execution;
 
 import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
 import org.opencds.cqf.cql.execution.Context;
-import org.opencds.cqf.cql.runtime.*;
+import org.opencds.cqf.cql.runtime.BaseTemporal;
+import org.opencds.cqf.cql.runtime.Date;
 import org.opencds.cqf.cql.runtime.DateTime;
 import org.opencds.cqf.cql.runtime.Interval;
+import org.opencds.cqf.cql.runtime.Precision;
+import org.opencds.cqf.cql.runtime.Time;
 
 /*
 

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/DistinctEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/DistinctEvaluator.java
@@ -1,11 +1,10 @@
 package org.opencds.cqf.cql.elm.execution;
 
-import org.opencds.cqf.cql.execution.Context;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.StreamSupport;
+
+import org.opencds.cqf.cql.execution.Context;
 
 /*
 distinct(argument List<T>) List<T>

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/DivideEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/DivideEvaluator.java
@@ -1,13 +1,13 @@
 package org.opencds.cqf.cql.elm.execution;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
 import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
 import org.opencds.cqf.cql.execution.Context;
 import org.opencds.cqf.cql.runtime.Interval;
 import org.opencds.cqf.cql.runtime.Quantity;
 import org.opencds.cqf.cql.runtime.Value;
-
-import java.math.BigDecimal;
-import java.math.RoundingMode;
 
 /*
 /(left Decimal, right Decimal) Decimal

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/DurationBetweenEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/DurationBetweenEvaluator.java
@@ -2,9 +2,12 @@ package org.opencds.cqf.cql.elm.execution;
 
 import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
 import org.opencds.cqf.cql.execution.Context;
-import org.opencds.cqf.cql.runtime.*;
+import org.opencds.cqf.cql.runtime.BaseTemporal;
+import org.opencds.cqf.cql.runtime.Date;
 import org.opencds.cqf.cql.runtime.DateTime;
 import org.opencds.cqf.cql.runtime.Interval;
+import org.opencds.cqf.cql.runtime.Precision;
+import org.opencds.cqf.cql.runtime.Time;
 
 /*
 

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/EqualEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/EqualEvaluator.java
@@ -1,11 +1,11 @@
 package org.opencds.cqf.cql.elm.execution;
 
-import org.opencds.cqf.cql.execution.Context;
-import org.opencds.cqf.cql.runtime.*;
-
-import java.lang.reflect.Field;
 import java.math.BigDecimal;
-import java.util.Iterator;
+
+import org.opencds.cqf.cql.execution.Context;
+import org.opencds.cqf.cql.runtime.CqlList;
+import org.opencds.cqf.cql.runtime.CqlType;
+import org.opencds.cqf.cql.runtime.Interval;
 
 /*
 *** NOTES FOR CLINICAL OPERATORS ***

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/EquivalentEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/EquivalentEvaluator.java
@@ -1,12 +1,11 @@
 package org.opencds.cqf.cql.elm.execution;
 
-import org.opencds.cqf.cql.execution.Context;
-import org.opencds.cqf.cql.runtime.*;
-
-import java.lang.reflect.Field;
 import java.math.BigDecimal;
-import java.util.HashMap;
-import java.util.Iterator;
+
+import org.opencds.cqf.cql.execution.Context;
+import org.opencds.cqf.cql.runtime.CqlList;
+import org.opencds.cqf.cql.runtime.CqlType;
+import org.opencds.cqf.cql.runtime.Interval;
 
 /*
 *** NOTES FOR CLINICAL OPERATORS ***

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/ExceptEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/ExceptEvaluator.java
@@ -1,15 +1,14 @@
 package org.opencds.cqf.cql.elm.execution;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
 import org.opencds.cqf.cql.exception.UndefinedResult;
 import org.opencds.cqf.cql.execution.Context;
 import org.opencds.cqf.cql.runtime.BaseTemporal;
 import org.opencds.cqf.cql.runtime.Interval;
-import org.opencds.cqf.cql.runtime.Value;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 
 /*
 except(left Interval<T>, right Interval<T>) Interval<T>

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/Executable.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/Executable.java
@@ -2,10 +2,7 @@ package org.opencds.cqf.cql.elm.execution;
 
 import org.apache.commons.lang3.NotImplementedException;
 import org.opencds.cqf.cql.exception.CqlException;
-import org.opencds.cqf.cql.exception.CqlExceptionHandler;
 import org.opencds.cqf.cql.execution.Context;
-
-import java.util.function.Function;
 
 public class Executable
 {

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/ExpEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/ExpEvaluator.java
@@ -1,10 +1,10 @@
 package org.opencds.cqf.cql.elm.execution;
 
+import java.math.BigDecimal;
+
 import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
 import org.opencds.cqf.cql.exception.UndefinedResult;
 import org.opencds.cqf.cql.execution.Context;
-
-import java.math.BigDecimal;
 
 /*
 Exp(argument Decimal) Decimal

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/ExpandEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/ExpandEvaluator.java
@@ -1,12 +1,19 @@
 package org.opencds.cqf.cql.elm.execution;
 
 
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+
 import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
 import org.opencds.cqf.cql.execution.Context;
-import org.opencds.cqf.cql.runtime.*;
-
-import java.math.BigDecimal;
-import java.util.*;
+import org.opencds.cqf.cql.runtime.BaseTemporal;
+import org.opencds.cqf.cql.runtime.CqlList;
+import org.opencds.cqf.cql.runtime.Interval;
+import org.opencds.cqf.cql.runtime.Precision;
+import org.opencds.cqf.cql.runtime.Quantity;
 
 /*
 

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/FilterEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/FilterEvaluator.java
@@ -1,11 +1,11 @@
 package org.opencds.cqf.cql.elm.execution;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.cqframework.cql.elm.execution.Filter;
 import org.opencds.cqf.cql.execution.Context;
 import org.opencds.cqf.cql.execution.Variable;
-
-import java.util.ArrayList;
-import java.util.List;
 
 public class FilterEvaluator extends Filter {
 

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/FlattenEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/FlattenEvaluator.java
@@ -1,10 +1,10 @@
 package org.opencds.cqf.cql.elm.execution;
 
-import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
-import org.opencds.cqf.cql.execution.Context;
-
 import java.util.ArrayList;
 import java.util.List;
+
+import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
+import org.opencds.cqf.cql.execution.Context;
 
 /*
 flatten(argument List<List<T>>) List<T>

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/FloorEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/FloorEvaluator.java
@@ -1,9 +1,10 @@
 package org.opencds.cqf.cql.elm.execution;
 
+import java.math.BigDecimal;
+
 import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
 import org.opencds.cqf.cql.execution.Context;
 import org.opencds.cqf.cql.runtime.Quantity;
-import java.math.BigDecimal;
 
 /*
 Floor(argument Decimal) Integer

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/ForEachEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/ForEachEvaluator.java
@@ -1,10 +1,10 @@
 package org.opencds.cqf.cql.elm.execution;
 
 
-import org.opencds.cqf.cql.execution.Context;
-
 import java.util.ArrayList;
 import java.util.List;
+
+import org.opencds.cqf.cql.execution.Context;
 
 public class ForEachEvaluator extends org.cqframework.cql.elm.execution.ForEach {
 

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/FunctionRefEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/FunctionRefEvaluator.java
@@ -1,12 +1,12 @@
 package org.opencds.cqf.cql.elm.execution;
 
+import java.util.ArrayList;
+import java.util.Optional;
+
 import org.cqframework.cql.elm.execution.Expression;
 import org.cqframework.cql.elm.execution.FunctionDef;
 import org.opencds.cqf.cql.execution.Context;
 import org.opencds.cqf.cql.execution.Variable;
-
-import java.util.ArrayList;
-import java.util.Optional;
 
 public class FunctionRefEvaluator extends org.cqframework.cql.elm.execution.FunctionRef {
 

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/GeometricMeanEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/GeometricMeanEvaluator.java
@@ -1,11 +1,11 @@
 package org.opencds.cqf.cql.elm.execution;
 
-import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
-import org.opencds.cqf.cql.execution.Context;
-
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
+
+import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
+import org.opencds.cqf.cql.execution.Context;
 
 /*
 

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/GreaterEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/GreaterEvaluator.java
@@ -1,10 +1,12 @@
 package org.opencds.cqf.cql.elm.execution;
 
+import java.math.BigDecimal;
+
 import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
 import org.opencds.cqf.cql.execution.Context;
-import org.opencds.cqf.cql.runtime.*;
-
-import java.math.BigDecimal;
+import org.opencds.cqf.cql.runtime.BaseTemporal;
+import org.opencds.cqf.cql.runtime.Interval;
+import org.opencds.cqf.cql.runtime.Quantity;
 
 /*
 

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/GreaterOrEqualEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/GreaterOrEqualEvaluator.java
@@ -1,10 +1,12 @@
 package org.opencds.cqf.cql.elm.execution;
 
+import java.math.BigDecimal;
+
 import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
 import org.opencds.cqf.cql.execution.Context;
-import org.opencds.cqf.cql.runtime.*;
-
-import java.math.BigDecimal;
+import org.opencds.cqf.cql.runtime.BaseTemporal;
+import org.opencds.cqf.cql.runtime.Interval;
+import org.opencds.cqf.cql.runtime.Quantity;
 
 /*
 >=(left Integer, right Integer) Boolean

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/InCodeSystemEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/InCodeSystemEvaluator.java
@@ -1,7 +1,7 @@
 package org.opencds.cqf.cql.elm.execution;
 
-import org.cqframework.cql.elm.execution.CodeSystemRef;
 import org.cqframework.cql.elm.execution.CodeSystemDef;
+import org.cqframework.cql.elm.execution.CodeSystemRef;
 import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
 import org.opencds.cqf.cql.execution.Context;
 import org.opencds.cqf.cql.runtime.Code;

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/InEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/InEvaluator.java
@@ -1,11 +1,11 @@
 package org.opencds.cqf.cql.elm.execution;
 
+import java.util.Arrays;
+
 import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
 import org.opencds.cqf.cql.execution.Context;
 import org.opencds.cqf.cql.runtime.BaseTemporal;
 import org.opencds.cqf.cql.runtime.Interval;
-
-import java.util.Arrays;
 
 /*
 *** NOTES FOR INTERVAL ***

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/InValueSetEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/InValueSetEvaluator.java
@@ -1,9 +1,9 @@
 package org.opencds.cqf.cql.elm.execution;
 
-import org.cqframework.cql.elm.execution.ValueSetRef;
-import org.cqframework.cql.elm.execution.ValueSetDef;
-import org.cqframework.cql.elm.execution.CodeSystemRef;
 import org.cqframework.cql.elm.execution.CodeSystemDef;
+import org.cqframework.cql.elm.execution.CodeSystemRef;
+import org.cqframework.cql.elm.execution.ValueSetDef;
+import org.cqframework.cql.elm.execution.ValueSetRef;
 import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
 import org.opencds.cqf.cql.execution.Context;
 import org.opencds.cqf.cql.runtime.Code;
@@ -11,8 +11,6 @@ import org.opencds.cqf.cql.runtime.Concept;
 import org.opencds.cqf.cql.terminology.CodeSystemInfo;
 import org.opencds.cqf.cql.terminology.TerminologyProvider;
 import org.opencds.cqf.cql.terminology.ValueSetInfo;
-import java.util.List;
-import java.util.ArrayList;
 
 /*
 in(code String, valueset ValueSetRef) Boolean

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/IncludedInEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/IncludedInEvaluator.java
@@ -1,11 +1,11 @@
 package org.opencds.cqf.cql.elm.execution;
 
+import java.util.Arrays;
+
 import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
 import org.opencds.cqf.cql.execution.Context;
 import org.opencds.cqf.cql.runtime.BaseTemporal;
 import org.opencds.cqf.cql.runtime.Interval;
-
-import java.util.Arrays;
 
 /*
 *** NOTES FOR INTERVAL ***

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/IndexOfEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/IndexOfEvaluator.java
@@ -1,7 +1,6 @@
 package org.opencds.cqf.cql.elm.execution;
 
 import org.opencds.cqf.cql.execution.Context;
-import org.opencds.cqf.cql.runtime.Value;
 
 /*
 IndexOf(argument List<T>, element T) Integer

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/IntersectEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/IntersectEvaluator.java
@@ -1,13 +1,12 @@
 package org.opencds.cqf.cql.elm.execution;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
 import org.opencds.cqf.cql.execution.Context;
 import org.opencds.cqf.cql.runtime.BaseTemporal;
 import org.opencds.cqf.cql.runtime.Interval;
-import org.opencds.cqf.cql.runtime.Precision;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /*
 *** NOTES FOR INTERVAL ***

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/IsEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/IsEvaluator.java
@@ -1,8 +1,6 @@
 package org.opencds.cqf.cql.elm.execution;
 
 import org.opencds.cqf.cql.execution.Context;
-import org.opencds.cqf.cql.runtime.Quantity;
-import java.math.BigDecimal;
 
 /*
 is<T>(argument Any) Boolean

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/LengthEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/LengthEvaluator.java
@@ -1,10 +1,10 @@
 package org.opencds.cqf.cql.elm.execution;
 
+import java.util.stream.StreamSupport;
+
 import org.cqframework.cql.elm.execution.NamedTypeSpecifier;
 import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
 import org.opencds.cqf.cql.execution.Context;
-
-import java.util.stream.StreamSupport;
 
 /*
 *** LIST NOTES ***

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/LessEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/LessEvaluator.java
@@ -1,10 +1,12 @@
 package org.opencds.cqf.cql.elm.execution;
 
+import java.math.BigDecimal;
+
 import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
 import org.opencds.cqf.cql.execution.Context;
-import org.opencds.cqf.cql.runtime.*;
-
-import java.math.BigDecimal;
+import org.opencds.cqf.cql.runtime.BaseTemporal;
+import org.opencds.cqf.cql.runtime.Interval;
+import org.opencds.cqf.cql.runtime.Quantity;
 
 /*
 <(left Integer, right Integer) Boolean

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/LessOrEqualEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/LessOrEqualEvaluator.java
@@ -1,10 +1,12 @@
 package org.opencds.cqf.cql.elm.execution;
 
+import java.math.BigDecimal;
+
 import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
 import org.opencds.cqf.cql.execution.Context;
-import org.opencds.cqf.cql.runtime.*;
-
-import java.math.BigDecimal;
+import org.opencds.cqf.cql.runtime.BaseTemporal;
+import org.opencds.cqf.cql.runtime.Interval;
+import org.opencds.cqf.cql.runtime.Quantity;
 
 /*
 <=(left Integer, right Integer) Boolean

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/ListEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/ListEvaluator.java
@@ -1,8 +1,8 @@
 package org.opencds.cqf.cql.elm.execution;
 
-import org.opencds.cqf.cql.execution.Context;
-
 import java.util.ArrayList;
+
+import org.opencds.cqf.cql.execution.Context;
 
 public class ListEvaluator extends org.cqframework.cql.elm.execution.List {
 

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/LiteralEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/LiteralEvaluator.java
@@ -1,10 +1,10 @@
 package org.opencds.cqf.cql.elm.execution;
 
+import java.math.BigDecimal;
+
 import org.opencds.cqf.cql.exception.CqlException;
 import org.opencds.cqf.cql.exception.InvalidLiteral;
 import org.opencds.cqf.cql.execution.Context;
-
-import java.math.BigDecimal;
 
 public class LiteralEvaluator extends org.cqframework.cql.elm.execution.Literal {
 

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/LnEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/LnEvaluator.java
@@ -1,11 +1,11 @@
 package org.opencds.cqf.cql.elm.execution;
 
+import java.math.BigDecimal;
+
 import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
 import org.opencds.cqf.cql.exception.UndefinedResult;
 import org.opencds.cqf.cql.execution.Context;
 import org.opencds.cqf.cql.runtime.Value;
-
-import java.math.BigDecimal;
 
 /*
 Ln(argument Decimal) Decimal

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/LogEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/LogEvaluator.java
@@ -1,11 +1,10 @@
 package org.opencds.cqf.cql.elm.execution;
 
+import java.math.BigDecimal;
+
 import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
-import org.opencds.cqf.cql.exception.UndefinedResult;
 import org.opencds.cqf.cql.execution.Context;
 import org.opencds.cqf.cql.runtime.Value;
-
-import java.math.BigDecimal;
 
 /*
 Log(argument Decimal, base Decimal) Decimal

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/MatchesEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/MatchesEvaluator.java
@@ -2,9 +2,6 @@ package org.opencds.cqf.cql.elm.execution;
 
 import org.opencds.cqf.cql.execution.Context;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 public class MatchesEvaluator extends org.cqframework.cql.elm.execution.Matches {
 
     public static Object matches(String argument, String pattern) {

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/MaxEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/MaxEvaluator.java
@@ -1,8 +1,9 @@
 package org.opencds.cqf.cql.elm.execution;
 
+import java.util.Iterator;
+
 import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
 import org.opencds.cqf.cql.execution.Context;
-import java.util.Iterator;
 
 /*
 Max(argument List<Integer>) Integer

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/MaxValueEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/MaxValueEvaluator.java
@@ -2,7 +2,13 @@ package org.opencds.cqf.cql.elm.execution;
 
 import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
 import org.opencds.cqf.cql.execution.Context;
-import org.opencds.cqf.cql.runtime.*;
+import org.opencds.cqf.cql.runtime.Date;
+import org.opencds.cqf.cql.runtime.DateTime;
+import org.opencds.cqf.cql.runtime.Precision;
+import org.opencds.cqf.cql.runtime.Quantity;
+import org.opencds.cqf.cql.runtime.TemporalHelper;
+import org.opencds.cqf.cql.runtime.Time;
+import org.opencds.cqf.cql.runtime.Value;
 
 /*
 maximum<T>() T

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/MedianEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/MedianEvaluator.java
@@ -1,13 +1,13 @@
 package org.opencds.cqf.cql.elm.execution;
 
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Iterator;
+
 import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
 import org.opencds.cqf.cql.execution.Context;
 import org.opencds.cqf.cql.runtime.CqlList;
 import org.opencds.cqf.cql.runtime.Quantity;
-
-import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.Iterator;
 
 /*
 Median(argument List<Decimal>) Decimal

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/MeetsAfterEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/MeetsAfterEvaluator.java
@@ -2,7 +2,7 @@ package org.opencds.cqf.cql.elm.execution;
 
 import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
 import org.opencds.cqf.cql.execution.Context;
-import org.opencds.cqf.cql.runtime.*;
+import org.opencds.cqf.cql.runtime.Interval;
 
 /*
 meets after _precision_ (left Interval<T>, right Interval<T>) Boolean

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/MeetsBeforeEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/MeetsBeforeEvaluator.java
@@ -2,7 +2,7 @@ package org.opencds.cqf.cql.elm.execution;
 
 import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
 import org.opencds.cqf.cql.execution.Context;
-import org.opencds.cqf.cql.runtime.*;
+import org.opencds.cqf.cql.runtime.Interval;
 
 /*
 meets before _precision_ (left Interval<T>, right Interval<T>) Boolean

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/MeetsEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/MeetsEvaluator.java
@@ -2,7 +2,11 @@ package org.opencds.cqf.cql.elm.execution;
 
 import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
 import org.opencds.cqf.cql.execution.Context;
-import org.opencds.cqf.cql.runtime.*;
+import org.opencds.cqf.cql.runtime.BaseTemporal;
+import org.opencds.cqf.cql.runtime.DateTime;
+import org.opencds.cqf.cql.runtime.Interval;
+import org.opencds.cqf.cql.runtime.Precision;
+import org.opencds.cqf.cql.runtime.Time;
 
 /*
 meets _precision_ (left Interval<T>, right Interval<T>) Boolean

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/MinEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/MinEvaluator.java
@@ -1,8 +1,9 @@
 package org.opencds.cqf.cql.elm.execution;
 
+import java.util.Iterator;
+
 import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
 import org.opencds.cqf.cql.execution.Context;
-import java.util.Iterator;
 
 /*
 Min(argument List<Integer>) Integer

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/MinValueEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/MinValueEvaluator.java
@@ -2,7 +2,13 @@ package org.opencds.cqf.cql.elm.execution;
 
 import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
 import org.opencds.cqf.cql.execution.Context;
-import org.opencds.cqf.cql.runtime.*;
+import org.opencds.cqf.cql.runtime.Date;
+import org.opencds.cqf.cql.runtime.DateTime;
+import org.opencds.cqf.cql.runtime.Precision;
+import org.opencds.cqf.cql.runtime.Quantity;
+import org.opencds.cqf.cql.runtime.TemporalHelper;
+import org.opencds.cqf.cql.runtime.Time;
+import org.opencds.cqf.cql.runtime.Value;
 
 /*
 minimum<T>() T

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/ModeEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/ModeEvaluator.java
@@ -1,11 +1,11 @@
 package org.opencds.cqf.cql.elm.execution;
 
+import java.util.ArrayList;
+import java.util.Iterator;
+
 import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
 import org.opencds.cqf.cql.execution.Context;
 import org.opencds.cqf.cql.runtime.CqlList;
-
-import java.util.ArrayList;
-import java.util.Iterator;
 
 /*
 Mode(argument List<T>) T

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/ModuloEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/ModuloEvaluator.java
@@ -1,9 +1,10 @@
 package org.opencds.cqf.cql.elm.execution;
 
-import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
-import org.opencds.cqf.cql.execution.Context;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+
+import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
+import org.opencds.cqf.cql.execution.Context;
 
 /*
 mod(left Integer, right Integer) Integer

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/MultiplyEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/MultiplyEvaluator.java
@@ -1,12 +1,12 @@
 package org.opencds.cqf.cql.elm.execution;
 
+import java.math.BigDecimal;
+
 import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
 import org.opencds.cqf.cql.execution.Context;
 import org.opencds.cqf.cql.runtime.Interval;
 import org.opencds.cqf.cql.runtime.Quantity;
 import org.opencds.cqf.cql.runtime.Value;
-
-import java.math.BigDecimal;
 
 /*
 *(left Integer, right Integer) Integer

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/NegateEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/NegateEvaluator.java
@@ -1,10 +1,11 @@
 package org.opencds.cqf.cql.elm.execution;
 
+import java.math.BigDecimal;
+
 import org.cqframework.cql.elm.execution.Expression;
 import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
 import org.opencds.cqf.cql.execution.Context;
 import org.opencds.cqf.cql.runtime.Quantity;
-import java.math.BigDecimal;
 
 /*
 -(argument Integer) Integer

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/ObjectFactoryEx.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/ObjectFactoryEx.java
@@ -1,8 +1,8 @@
 package org.opencds.cqf.cql.elm.execution;
 
-import org.cqframework.cql.elm.execution.*;
-
 import javax.xml.bind.annotation.XmlRegistry;
+
+import org.cqframework.cql.elm.execution.*;
 
 @XmlRegistry
 public class ObjectFactoryEx extends org.cqframework.cql.elm.execution.ObjectFactory {

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/PointFromEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/PointFromEvaluator.java
@@ -2,8 +2,8 @@ package org.opencds.cqf.cql.elm.execution;
 
 import org.opencds.cqf.cql.exception.InvalidInterval;
 import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
-import org.opencds.cqf.cql.runtime.Interval;
 import org.opencds.cqf.cql.execution.Context;
+import org.opencds.cqf.cql.runtime.Interval;
 
 /*
 point from(argument Interval<T>) : T

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/PopulationStdDevEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/PopulationStdDevEvaluator.java
@@ -1,11 +1,11 @@
 package org.opencds.cqf.cql.elm.execution;
 
+import java.math.BigDecimal;
+import java.util.List;
+
 import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
 import org.opencds.cqf.cql.execution.Context;
 import org.opencds.cqf.cql.runtime.Quantity;
-
-import java.math.BigDecimal;
-import java.util.List;
 
 /*
 PopulationStdDev(argument List<Decimal>) Decimal

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/PopulationVarianceEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/PopulationVarianceEvaluator.java
@@ -1,10 +1,10 @@
 package org.opencds.cqf.cql.elm.execution;
 
-import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
-import org.opencds.cqf.cql.execution.Context;
-
 import java.util.ArrayList;
 import java.util.List;
+
+import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
+import org.opencds.cqf.cql.execution.Context;
 
 /*
 PopulationVariance(argument List<Decimal>) Decimal

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/PowerEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/PowerEvaluator.java
@@ -1,10 +1,10 @@
 package org.opencds.cqf.cql.elm.execution;
 
+import java.math.BigDecimal;
+
 import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
 import org.opencds.cqf.cql.execution.Context;
 import org.opencds.cqf.cql.runtime.Value;
-
-import java.math.BigDecimal;
 
 /*
 ^(argument Integer, exponent Integer) Integer

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/PredecessorEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/PredecessorEvaluator.java
@@ -1,11 +1,16 @@
 package org.opencds.cqf.cql.elm.execution;
 
+import java.math.BigDecimal;
+
 import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
 import org.opencds.cqf.cql.exception.TypeUnderflow;
 import org.opencds.cqf.cql.execution.Context;
-import org.opencds.cqf.cql.runtime.*;
-
-import java.math.BigDecimal;
+import org.opencds.cqf.cql.runtime.Date;
+import org.opencds.cqf.cql.runtime.DateTime;
+import org.opencds.cqf.cql.runtime.Precision;
+import org.opencds.cqf.cql.runtime.Quantity;
+import org.opencds.cqf.cql.runtime.Time;
+import org.opencds.cqf.cql.runtime.Value;
 
 /*
 predecessor of<T>(argument T) T

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/ProductEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/ProductEvaluator.java
@@ -1,11 +1,10 @@
 package org.opencds.cqf.cql.elm.execution;
 
+import java.math.BigDecimal;
+
 import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
 import org.opencds.cqf.cql.execution.Context;
 import org.opencds.cqf.cql.runtime.Quantity;
-
-import java.math.BigDecimal;
-import java.util.List;
 
 /*
 

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/ProperContainsEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/ProperContainsEvaluator.java
@@ -1,11 +1,11 @@
 package org.opencds.cqf.cql.elm.execution;
 
+import java.util.List;
+
 import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
 import org.opencds.cqf.cql.execution.Context;
 import org.opencds.cqf.cql.runtime.BaseTemporal;
 import org.opencds.cqf.cql.runtime.Interval;
-
-import java.util.List;
 
 /*
     There are two overloads of this operator:

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/ProperlyIncludesEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/ProperlyIncludesEvaluator.java
@@ -1,11 +1,11 @@
 package org.opencds.cqf.cql.elm.execution;
 
+import java.util.stream.StreamSupport;
+
 import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
 import org.opencds.cqf.cql.execution.Context;
 import org.opencds.cqf.cql.runtime.BaseTemporal;
 import org.opencds.cqf.cql.runtime.Interval;
-
-import java.util.stream.StreamSupport;
 
 /*
 *** NOTES FOR INTERVAL ***

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/QuantityEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/QuantityEvaluator.java
@@ -1,9 +1,9 @@
 package org.opencds.cqf.cql.elm.execution;
 
+import java.math.BigDecimal;
+
 import org.opencds.cqf.cql.execution.Context;
 import org.opencds.cqf.cql.runtime.Value;
-
-import java.math.BigDecimal;
 
 /*
 structured type Quantity

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/QueryEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/QueryEvaluator.java
@@ -1,5 +1,10 @@
 package org.opencds.cqf.cql.elm.execution;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+
 import org.cqframework.cql.elm.execution.AliasedQuerySource;
 import org.cqframework.cql.elm.execution.ByColumn;
 import org.cqframework.cql.elm.execution.ByExpression;
@@ -9,8 +14,6 @@ import org.opencds.cqf.cql.execution.Variable;
 import org.opencds.cqf.cql.runtime.CqlList;
 import org.opencds.cqf.cql.runtime.Tuple;
 import org.opencds.cqf.cql.runtime.iterators.QueryIterator;
-
-import java.util.*;
 
 public class QueryEvaluator extends org.cqframework.cql.elm.execution.Query {
 

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/RetrieveEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/RetrieveEvaluator.java
@@ -1,16 +1,15 @@
 package org.opencds.cqf.cql.elm.execution;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.cqframework.cql.elm.execution.ValueSetDef;
+import org.cqframework.cql.elm.execution.ValueSetRef;
 import org.opencds.cqf.cql.data.DataProvider;
 import org.opencds.cqf.cql.execution.Context;
 import org.opencds.cqf.cql.runtime.Code;
 import org.opencds.cqf.cql.runtime.Concept;
 import org.opencds.cqf.cql.runtime.Interval;
-import org.cqframework.cql.elm.execution.ValueSetRef;
-import org.cqframework.cql.elm.execution.ValueSetDef;
-
-
-import java.util.ArrayList;
-import java.util.List;
 
 public class RetrieveEvaluator extends org.cqframework.cql.elm.execution.Retrieve {
 

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/RoundEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/RoundEvaluator.java
@@ -1,9 +1,10 @@
 package org.opencds.cqf.cql.elm.execution;
 
-import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
-import org.opencds.cqf.cql.execution.Context;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+
+import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
+import org.opencds.cqf.cql.execution.Context;
 
 /*
 Round(argument Decimal) Decimal

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/SameAsEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/SameAsEvaluator.java
@@ -2,7 +2,9 @@ package org.opencds.cqf.cql.elm.execution;
 
 import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
 import org.opencds.cqf.cql.execution.Context;
-import org.opencds.cqf.cql.runtime.*;
+import org.opencds.cqf.cql.runtime.BaseTemporal;
+import org.opencds.cqf.cql.runtime.Interval;
+import org.opencds.cqf.cql.runtime.Precision;
 
 /*
 

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/SameOrAfterEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/SameOrAfterEvaluator.java
@@ -2,7 +2,9 @@ package org.opencds.cqf.cql.elm.execution;
 
 import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
 import org.opencds.cqf.cql.execution.Context;
-import org.opencds.cqf.cql.runtime.*;
+import org.opencds.cqf.cql.runtime.BaseTemporal;
+import org.opencds.cqf.cql.runtime.Interval;
+import org.opencds.cqf.cql.runtime.Precision;
 
 /*
 *** SameOrAfter Temporal Overload ***

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/SameOrBeforeEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/SameOrBeforeEvaluator.java
@@ -2,7 +2,9 @@ package org.opencds.cqf.cql.elm.execution;
 
 import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
 import org.opencds.cqf.cql.execution.Context;
-import org.opencds.cqf.cql.runtime.*;
+import org.opencds.cqf.cql.runtime.BaseTemporal;
+import org.opencds.cqf.cql.runtime.Interval;
+import org.opencds.cqf.cql.runtime.Precision;
 
 /*
 *** SameOrBefore Temporal Overload ***

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/SliceEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/SliceEvaluator.java
@@ -1,10 +1,10 @@
 package org.opencds.cqf.cql.elm.execution;
 
-import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
-import org.opencds.cqf.cql.execution.Context;
-
 import java.util.ArrayList;
 import java.util.List;
+
+import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
+import org.opencds.cqf.cql.execution.Context;
 
 /*
 * The ELM Slice operation is the foundation for 3 CQL operators:

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/SplitEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/SplitEvaluator.java
@@ -1,10 +1,11 @@
 package org.opencds.cqf.cql.elm.execution;
 
-import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
-import org.opencds.cqf.cql.execution.Context;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+
+import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
+import org.opencds.cqf.cql.execution.Context;
 
 /*
 Split(stringToSplit String, separator String) List<String>

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/StdDevEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/StdDevEvaluator.java
@@ -1,11 +1,11 @@
 package org.opencds.cqf.cql.elm.execution;
 
+import java.math.BigDecimal;
+import java.util.List;
+
 import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
 import org.opencds.cqf.cql.execution.Context;
 import org.opencds.cqf.cql.runtime.Quantity;
-
-import java.math.BigDecimal;
-import java.util.List;
 
 /*
 StdDev(argument List<Decimal>) Decimal

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/SubtractEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/SubtractEvaluator.java
@@ -1,10 +1,17 @@
 package org.opencds.cqf.cql.elm.execution;
 
+import java.math.BigDecimal;
+
 import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
 import org.opencds.cqf.cql.execution.Context;
-import org.opencds.cqf.cql.runtime.*;
-
-import java.math.BigDecimal;
+import org.opencds.cqf.cql.runtime.BaseTemporal;
+import org.opencds.cqf.cql.runtime.Date;
+import org.opencds.cqf.cql.runtime.DateTime;
+import org.opencds.cqf.cql.runtime.Interval;
+import org.opencds.cqf.cql.runtime.Precision;
+import org.opencds.cqf.cql.runtime.Quantity;
+import org.opencds.cqf.cql.runtime.TemporalHelper;
+import org.opencds.cqf.cql.runtime.Time;
 
 /*
 

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/SuccessorEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/SuccessorEvaluator.java
@@ -1,11 +1,16 @@
 package org.opencds.cqf.cql.elm.execution;
 
+import java.math.BigDecimal;
+
 import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
 import org.opencds.cqf.cql.exception.TypeOverflow;
 import org.opencds.cqf.cql.execution.Context;
-import org.opencds.cqf.cql.runtime.*;
-
-import java.math.BigDecimal;
+import org.opencds.cqf.cql.runtime.Date;
+import org.opencds.cqf.cql.runtime.DateTime;
+import org.opencds.cqf.cql.runtime.Precision;
+import org.opencds.cqf.cql.runtime.Quantity;
+import org.opencds.cqf.cql.runtime.Time;
+import org.opencds.cqf.cql.runtime.Value;
 
 /*
 successor of<T>(argument T) T

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/SumEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/SumEvaluator.java
@@ -2,9 +2,6 @@ package org.opencds.cqf.cql.elm.execution;
 
 import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
 import org.opencds.cqf.cql.execution.Context;
-import org.opencds.cqf.cql.runtime.Quantity;
-import java.util.Iterator;
-import java.math.BigDecimal;
 
 /*
 Sum(argument List<Integer>) Integer

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/TimeEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/TimeEvaluator.java
@@ -1,8 +1,8 @@
 package org.opencds.cqf.cql.elm.execution;
 
-import org.opencds.cqf.cql.execution.Context;
-
 import java.math.BigDecimal;
+
+import org.opencds.cqf.cql.execution.Context;
 import org.opencds.cqf.cql.runtime.TemporalHelper;
 import org.opencds.cqf.cql.runtime.Time;
 

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/ToConceptEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/ToConceptEvaluator.java
@@ -2,8 +2,8 @@ package org.opencds.cqf.cql.elm.execution;
 
 import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
 import org.opencds.cqf.cql.execution.Context;
-import org.opencds.cqf.cql.runtime.Concept;
 import org.opencds.cqf.cql.runtime.Code;
+import org.opencds.cqf.cql.runtime.Concept;
 
 /*
 ToConcept(argument Code) Concept

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/ToDateEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/ToDateEvaluator.java
@@ -1,12 +1,12 @@
 package org.opencds.cqf.cql.elm.execution;
 
+import java.time.format.DateTimeParseException;
+
 import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
 import org.opencds.cqf.cql.execution.Context;
 import org.opencds.cqf.cql.runtime.Date;
 import org.opencds.cqf.cql.runtime.DateTime;
 import org.opencds.cqf.cql.runtime.Precision;
-
-import java.time.format.DateTimeParseException;
 
 /*
 

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/ToDateTimeEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/ToDateTimeEvaluator.java
@@ -1,12 +1,12 @@
 package org.opencds.cqf.cql.elm.execution;
 
+import java.time.format.DateTimeParseException;
+
 import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
 import org.opencds.cqf.cql.execution.Context;
 import org.opencds.cqf.cql.runtime.Date;
 import org.opencds.cqf.cql.runtime.DateTime;
 import org.opencds.cqf.cql.runtime.TemporalHelper;
-
-import java.time.format.DateTimeParseException;
 
 /*
 

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/ToDecimalEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/ToDecimalEvaluator.java
@@ -1,10 +1,10 @@
 package org.opencds.cqf.cql.elm.execution;
 
+import java.math.BigDecimal;
+
 import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
 import org.opencds.cqf.cql.execution.Context;
 import org.opencds.cqf.cql.runtime.Value;
-
-import java.math.BigDecimal;
 
 /*
 

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/ToListEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/ToListEvaluator.java
@@ -1,7 +1,8 @@
 package org.opencds.cqf.cql.elm.execution;
 
-import org.opencds.cqf.cql.execution.Context;
 import java.util.Collections;
+
+import org.opencds.cqf.cql.execution.Context;
 
 public class ToListEvaluator extends org.cqframework.cql.elm.execution.ToList {
 

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/ToQuantityEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/ToQuantityEvaluator.java
@@ -1,10 +1,10 @@
 package org.opencds.cqf.cql.elm.execution;
 
+import java.math.BigDecimal;
+
 import org.opencds.cqf.cql.execution.Context;
 import org.opencds.cqf.cql.runtime.Quantity;
 import org.opencds.cqf.cql.runtime.Value;
-
-import java.math.BigDecimal;
 
 /*
 ToQuantity(argument Decimal) Quantity

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/ToStringEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/ToStringEvaluator.java
@@ -1,12 +1,12 @@
 package org.opencds.cqf.cql.elm.execution;
 
+import java.math.BigDecimal;
+
 import org.opencds.cqf.cql.execution.Context;
 import org.opencds.cqf.cql.runtime.Date;
 import org.opencds.cqf.cql.runtime.DateTime;
 import org.opencds.cqf.cql.runtime.Quantity;
 import org.opencds.cqf.cql.runtime.Time;
-
-import java.math.BigDecimal;
 
 /*
 

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/ToTimeEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/ToTimeEvaluator.java
@@ -1,10 +1,10 @@
 package org.opencds.cqf.cql.elm.execution;
 
+import java.time.format.DateTimeParseException;
+
 import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
 import org.opencds.cqf.cql.execution.Context;
 import org.opencds.cqf.cql.runtime.Time;
-
-import java.time.format.DateTimeParseException;
 
 /*
 

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/TruncateEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/TruncateEvaluator.java
@@ -1,9 +1,9 @@
 package org.opencds.cqf.cql.elm.execution;
 
+import java.math.BigDecimal;
+
 import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
 import org.opencds.cqf.cql.execution.Context;
-
-import java.math.BigDecimal;
 
 /*
 Truncate(argument Decimal) Integer

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/TruncatedDivideEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/TruncatedDivideEvaluator.java
@@ -1,10 +1,10 @@
 package org.opencds.cqf.cql.elm.execution;
 
+import java.math.BigDecimal;
+
 import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
 import org.opencds.cqf.cql.execution.Context;
 import org.opencds.cqf.cql.runtime.Interval;
-
-import java.math.BigDecimal;
 
 /*
 div(left Integer, right Integer) Integer

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/TupleEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/TupleEvaluator.java
@@ -1,7 +1,8 @@
 package org.opencds.cqf.cql.elm.execution;
 
-import org.opencds.cqf.cql.execution.Context;
 import java.util.HashMap;
+
+import org.opencds.cqf.cql.execution.Context;
 
 public class TupleEvaluator extends org.cqframework.cql.elm.execution.Tuple {
 

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/UnionEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/UnionEvaluator.java
@@ -1,12 +1,12 @@
 package org.opencds.cqf.cql.elm.execution;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
 import org.opencds.cqf.cql.execution.Context;
 import org.opencds.cqf.cql.runtime.BaseTemporal;
 import org.opencds.cqf.cql.runtime.Interval;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /*
 *** NOTES FOR INTERVAL ***

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/VarianceEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/VarianceEvaluator.java
@@ -1,12 +1,12 @@
 package org.opencds.cqf.cql.elm.execution;
 
-import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
-import org.opencds.cqf.cql.execution.Context;
-import org.opencds.cqf.cql.runtime.Quantity;
-
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
+
+import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
+import org.opencds.cqf.cql.execution.Context;
+import org.opencds.cqf.cql.runtime.Quantity;
 
 /*
 Variance(argument List<Decimal>) Decimal

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/exception/CqlException.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/exception/CqlException.java
@@ -1,7 +1,5 @@
 package org.opencds.cqf.cql.exception;
 
-import org.apache.commons.lang3.exception.ExceptionUtils;
-
 public class CqlException extends RuntimeException
 {
     public CqlException(String message)

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/execution/Context.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/execution/Context.java
@@ -1,6 +1,31 @@
 package org.opencds.cqf.cql.execution;
 
-import org.cqframework.cql.elm.execution.*;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Stack;
+
+import javax.xml.namespace.QName;
+
+import org.cqframework.cql.elm.execution.ChoiceTypeSpecifier;
+import org.cqframework.cql.elm.execution.CodeDef;
+import org.cqframework.cql.elm.execution.CodeSystemDef;
+import org.cqframework.cql.elm.execution.ExpressionDef;
+import org.cqframework.cql.elm.execution.FunctionDef;
+import org.cqframework.cql.elm.execution.IncludeDef;
+import org.cqframework.cql.elm.execution.IntervalTypeSpecifier;
+import org.cqframework.cql.elm.execution.Library;
+import org.cqframework.cql.elm.execution.ListTypeSpecifier;
+import org.cqframework.cql.elm.execution.NamedTypeSpecifier;
+import org.cqframework.cql.elm.execution.OperandDef;
+import org.cqframework.cql.elm.execution.ParameterDef;
+import org.cqframework.cql.elm.execution.Tuple;
+import org.cqframework.cql.elm.execution.TypeSpecifier;
+import org.cqframework.cql.elm.execution.ValueSetDef;
+import org.cqframework.cql.elm.execution.VersionedIdentifier;
 import org.opencds.cqf.cql.data.DataProvider;
 import org.opencds.cqf.cql.data.ExternalFunctionProvider;
 import org.opencds.cqf.cql.data.SystemDataProvider;
@@ -8,11 +33,6 @@ import org.opencds.cqf.cql.exception.CqlException;
 import org.opencds.cqf.cql.runtime.Precision;
 import org.opencds.cqf.cql.runtime.TemporalHelper;
 import org.opencds.cqf.cql.terminology.TerminologyProvider;
-
-import javax.xml.namespace.QName;
-import java.time.OffsetDateTime;
-import java.util.*;
-import java.util.List;
 
 /**
  * NOTE: This class is thread-affine; it uses thread local storage to allow statics throughout the code base to access

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/execution/CqlEngine.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/execution/CqlEngine.java
@@ -1,5 +1,11 @@
 package org.opencds.cqf.cql.execution;
 
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
 import org.cqframework.cql.elm.execution.ExpressionDef;
 import org.cqframework.cql.elm.execution.FunctionDef;
 import org.cqframework.cql.elm.execution.Library;
@@ -7,15 +13,6 @@ import org.cqframework.cql.elm.execution.UsingDef;
 import org.cqframework.cql.elm.execution.VersionedIdentifier;
 import org.opencds.cqf.cql.data.DataProvider;
 import org.opencds.cqf.cql.terminology.TerminologyProvider;
-
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
 /**
  * NOTE: Several possible approaches to traversing the ELM tree for execution:

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/execution/CqlLibraryReader.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/execution/CqlLibraryReader.java
@@ -1,16 +1,5 @@
 package org.opencds.cqf.cql.execution;
 
-import org.cqframework.cql.elm.execution.Library;
-import org.cqframework.cql.elm.execution.ObjectFactory;
-import org.opencds.cqf.cql.elm.execution.ObjectFactoryEx;
-import org.opencds.cqf.cql.exception.CqlException;
-
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBElement;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Unmarshaller;
-import javax.xml.transform.Source;
-import javax.xml.transform.stream.StreamSource;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -18,6 +7,18 @@ import java.io.Reader;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBElement;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Unmarshaller;
+import javax.xml.transform.Source;
+import javax.xml.transform.stream.StreamSource;
+
+import org.cqframework.cql.elm.execution.Library;
+import org.cqframework.cql.elm.execution.ObjectFactory;
+import org.opencds.cqf.cql.elm.execution.ObjectFactoryEx;
+import org.opencds.cqf.cql.exception.CqlException;
 
 public class CqlLibraryReader {
 

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/runtime/Concept.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/runtime/Concept.java
@@ -1,9 +1,10 @@
 package org.opencds.cqf.cql.runtime;
 
-import org.opencds.cqf.cql.elm.execution.EqualEvaluator;
-import org.opencds.cqf.cql.elm.execution.EquivalentEvaluator;
 import java.util.ArrayList;
 import java.util.List;
+
+import org.opencds.cqf.cql.elm.execution.EqualEvaluator;
+import org.opencds.cqf.cql.elm.execution.EquivalentEvaluator;
 
 public class Concept implements CqlType {
     private String display;

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/runtime/CqlList.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/runtime/CqlList.java
@@ -1,16 +1,16 @@
 package org.opencds.cqf.cql.runtime;
 
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+
 import org.cqframework.cql.elm.execution.Expression;
 import org.opencds.cqf.cql.elm.execution.EqualEvaluator;
 import org.opencds.cqf.cql.elm.execution.EquivalentEvaluator;
 import org.opencds.cqf.cql.exception.InvalidComparison;
 import org.opencds.cqf.cql.execution.Context;
 import org.opencds.cqf.cql.execution.Variable;
-
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.Iterator;
-import java.util.List;
 
 public class CqlList {
     private Context context;

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/runtime/Date.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/runtime/Date.java
@@ -1,9 +1,10 @@
 package org.opencds.cqf.cql.runtime;
 
-import org.opencds.cqf.cql.exception.InvalidDate;
+import java.time.LocalDate;
 
 import javax.annotation.Nonnull;
-import java.time.LocalDate;
+
+import org.opencds.cqf.cql.exception.InvalidDate;
 
 public class Date extends BaseTemporal {
 

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/runtime/DateTime.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/runtime/DateTime.java
@@ -1,14 +1,15 @@
 package org.opencds.cqf.cql.runtime;
 
-import org.opencds.cqf.cql.exception.InvalidDateTime;
-
-import javax.annotation.Nonnull;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.Calendar;
 import java.util.Date;
+
+import javax.annotation.Nonnull;
+
+import org.opencds.cqf.cql.exception.InvalidDateTime;
 
 public class DateTime extends BaseTemporal {
 

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/runtime/Interval.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/runtime/Interval.java
@@ -1,13 +1,23 @@
 package org.opencds.cqf.cql.runtime;
 
-import org.opencds.cqf.cql.elm.execution.*;
-import org.opencds.cqf.cql.exception.InvalidInterval;
-import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
-
-import javax.annotation.Nonnull;
 import java.lang.reflect.Type;
 import java.math.BigDecimal;
 import java.util.Date;
+
+import javax.annotation.Nonnull;
+
+import org.opencds.cqf.cql.elm.execution.AndEvaluator;
+import org.opencds.cqf.cql.elm.execution.EqualEvaluator;
+import org.opencds.cqf.cql.elm.execution.EquivalentEvaluator;
+import org.opencds.cqf.cql.elm.execution.GreaterEvaluator;
+import org.opencds.cqf.cql.elm.execution.IntersectEvaluator;
+import org.opencds.cqf.cql.elm.execution.MaxValueEvaluator;
+import org.opencds.cqf.cql.elm.execution.MinValueEvaluator;
+import org.opencds.cqf.cql.elm.execution.PredecessorEvaluator;
+import org.opencds.cqf.cql.elm.execution.SubtractEvaluator;
+import org.opencds.cqf.cql.elm.execution.SuccessorEvaluator;
+import org.opencds.cqf.cql.exception.InvalidInterval;
+import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
 
 public class Interval implements CqlType, Comparable<Interval> {
 

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/runtime/Precision.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/runtime/Precision.java
@@ -1,9 +1,9 @@
 package org.opencds.cqf.cql.runtime;
 
-import org.opencds.cqf.cql.exception.InvalidPrecision;
-
 import java.time.temporal.ChronoField;
 import java.time.temporal.ChronoUnit;
+
+import org.opencds.cqf.cql.exception.InvalidPrecision;
 
 public enum Precision {
     YEAR,

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/runtime/Quantity.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/runtime/Quantity.java
@@ -1,10 +1,11 @@
 package org.opencds.cqf.cql.runtime;
 
+import java.math.BigDecimal;
+
 import javax.annotation.Nonnull;
+
 import org.opencds.cqf.cql.elm.execution.EqualEvaluator;
 import org.opencds.cqf.cql.elm.execution.EquivalentEvaluator;
-
-import java.math.BigDecimal;
 
 public class Quantity implements CqlType, Comparable<Quantity> {
 

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/runtime/TemporalHelper.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/runtime/TemporalHelper.java
@@ -1,13 +1,13 @@
 package org.opencds.cqf.cql.runtime;
 
-import org.apache.commons.lang3.StringUtils;
-
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoField;
 import java.util.Arrays;
 import java.util.Objects;
+
+import org.apache.commons.lang3.StringUtils;
 
 public class TemporalHelper {
 

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/runtime/Time.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/runtime/Time.java
@@ -1,12 +1,13 @@
 package org.opencds.cqf.cql.runtime;
 
-import org.opencds.cqf.cql.exception.InvalidTime;
-
-import javax.annotation.Nonnull;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.OffsetTime;
 import java.time.ZoneOffset;
+
+import javax.annotation.Nonnull;
+
+import org.opencds.cqf.cql.exception.InvalidTime;
 
 public class Time extends BaseTemporal {
 

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/runtime/Value.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/runtime/Value.java
@@ -1,10 +1,10 @@
 package org.opencds.cqf.cql.runtime;
 
-import org.opencds.cqf.cql.elm.execution.MaxValueEvaluator;
-import org.opencds.cqf.cql.elm.execution.MinValueEvaluator;
-
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+
+import org.opencds.cqf.cql.elm.execution.MaxValueEvaluator;
+import org.opencds.cqf.cql.elm.execution.MinValueEvaluator;
 
 public class Value {
 

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/runtime/iterators/QueryIterator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/runtime/iterators/QueryIterator.java
@@ -1,13 +1,11 @@
 package org.opencds.cqf.cql.runtime.iterators;
 
-import org.opencds.cqf.cql.elm.execution.QueryEvaluator;
-import org.opencds.cqf.cql.execution.Context;
-
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-
 import java.util.Map;
+
+import org.opencds.cqf.cql.execution.Context;
 
 /**
  * Created by Bryn on 8/11/2019.

--- a/cql-engine/src/test/java/org/opencds/cqf/cql/data/SystemDataProviderTest.java
+++ b/cql-engine/src/test/java/org/opencds/cqf/cql/data/SystemDataProviderTest.java
@@ -1,10 +1,9 @@
 package org.opencds.cqf.cql.data;
 
-import org.opencds.cqf.cql.data.SystemDataProvider;
-import org.opencds.cqf.cql.runtime.*;
-import org.testng.annotations.Test;
-
 import static org.junit.Assert.assertNull;
+
+import org.opencds.cqf.cql.runtime.Date;
+import org.testng.annotations.Test;
 
 public class SystemDataProviderTest {
 

--- a/cql-engine/src/test/java/org/opencds/cqf/cql/execution/CqlAggregateFunctionsTest.java
+++ b/cql-engine/src/test/java/org/opencds/cqf/cql/execution/CqlAggregateFunctionsTest.java
@@ -1,5 +1,13 @@
 package org.opencds.cqf.cql.execution;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+
+import javax.xml.bind.JAXBException;
+
 import org.opencds.cqf.cql.elm.execution.AnyTrueEvaluator;
 import org.opencds.cqf.cql.elm.execution.AvgEvaluator;
 import org.opencds.cqf.cql.elm.execution.EquivalentEvaluator;
@@ -10,13 +18,6 @@ import org.opencds.cqf.cql.runtime.TemporalHelper;
 import org.opencds.cqf.cql.runtime.Time;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-
-import javax.xml.bind.JAXBException;
-import java.math.BigDecimal;
-import java.util.Arrays;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
 
 public class CqlAggregateFunctionsTest extends CqlExecutionTestBase {
 

--- a/cql-engine/src/test/java/org/opencds/cqf/cql/execution/CqlArithmeticFunctionsTest.java
+++ b/cql-engine/src/test/java/org/opencds/cqf/cql/execution/CqlArithmeticFunctionsTest.java
@@ -1,19 +1,26 @@
 package org.opencds.cqf.cql.execution;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.comparesEqualTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.math.BigDecimal;
+
+import javax.xml.bind.JAXBException;
+
 import org.opencds.cqf.cql.elm.execution.AbsEvaluator;
 import org.opencds.cqf.cql.elm.execution.AddEvaluator;
 import org.opencds.cqf.cql.elm.execution.EquivalentEvaluator;
 import org.opencds.cqf.cql.exception.CqlException;
 import org.opencds.cqf.cql.exception.UndefinedResult;
-import org.opencds.cqf.cql.runtime.*;
+import org.opencds.cqf.cql.runtime.DateTime;
+import org.opencds.cqf.cql.runtime.Quantity;
+import org.opencds.cqf.cql.runtime.TemporalHelper;
+import org.opencds.cqf.cql.runtime.Time;
+import org.opencds.cqf.cql.runtime.Value;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-
-import javax.xml.bind.JAXBException;
-import java.math.BigDecimal;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
 
 public class CqlArithmeticFunctionsTest extends CqlExecutionTestBase {
     /**

--- a/cql-engine/src/test/java/org/opencds/cqf/cql/execution/CqlClinicalOperatorsTest.java
+++ b/cql-engine/src/test/java/org/opencds/cqf/cql/execution/CqlClinicalOperatorsTest.java
@@ -1,16 +1,18 @@
 package org.opencds.cqf.cql.execution;
 
-import org.opencds.cqf.cql.runtime.DateTime;
-import org.opencds.cqf.cql.runtime.TemporalHelper;
-import org.testng.Assert;
-import org.testng.annotations.Test;
-import org.opencds.cqf.cql.runtime.Interval;
-import javax.xml.bind.JAXBException;
-import java.lang.reflect.InvocationTargetException;
-
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
+
+import java.lang.reflect.InvocationTargetException;
+
+import javax.xml.bind.JAXBException;
+
+import org.opencds.cqf.cql.runtime.DateTime;
+import org.opencds.cqf.cql.runtime.Interval;
+import org.opencds.cqf.cql.runtime.TemporalHelper;
+import org.testng.Assert;
+import org.testng.annotations.Test;
 
 public class CqlClinicalOperatorsTest extends CqlExecutionTestBase {
 

--- a/cql-engine/src/test/java/org/opencds/cqf/cql/execution/CqlComparisonOperatorsTest.java
+++ b/cql-engine/src/test/java/org/opencds/cqf/cql/execution/CqlComparisonOperatorsTest.java
@@ -1,13 +1,15 @@
 package org.opencds.cqf.cql.execution;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+import javax.xml.bind.JAXBException;
+
 import org.opencds.cqf.cql.elm.execution.GreaterEvaluator;
 import org.opencds.cqf.cql.exception.CqlException;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-import javax.xml.bind.JAXBException;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
 
 public class CqlComparisonOperatorsTest extends CqlExecutionTestBase {
 

--- a/cql-engine/src/test/java/org/opencds/cqf/cql/execution/CqlConditionalOperatorsTest.java
+++ b/cql-engine/src/test/java/org/opencds/cqf/cql/execution/CqlConditionalOperatorsTest.java
@@ -1,11 +1,11 @@
 package org.opencds.cqf.cql.execution;
 
-import org.testng.annotations.Test;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 import javax.xml.bind.JAXBException;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import org.testng.annotations.Test;
 
 public class CqlConditionalOperatorsTest extends CqlExecutionTestBase {
 

--- a/cql-engine/src/test/java/org/opencds/cqf/cql/execution/CqlDateTimeOperatorsTest.java
+++ b/cql-engine/src/test/java/org/opencds/cqf/cql/execution/CqlDateTimeOperatorsTest.java
@@ -1,19 +1,24 @@
 package org.opencds.cqf.cql.execution;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.math.BigDecimal;
+
+import javax.xml.bind.JAXBException;
+
 import org.opencds.cqf.cql.elm.execution.AfterEvaluator;
 import org.opencds.cqf.cql.elm.execution.EquivalentEvaluator;
 import org.opencds.cqf.cql.exception.CqlException;
 import org.opencds.cqf.cql.exception.InvalidDateTime;
-import org.opencds.cqf.cql.runtime.*;
+import org.opencds.cqf.cql.runtime.Date;
+import org.opencds.cqf.cql.runtime.DateTime;
+import org.opencds.cqf.cql.runtime.Interval;
+import org.opencds.cqf.cql.runtime.TemporalHelper;
+import org.opencds.cqf.cql.runtime.Time;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-
-import javax.xml.bind.JAXBException;
-import java.math.BigDecimal;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
 
 public class CqlDateTimeOperatorsTest extends CqlExecutionTestBase {
 

--- a/cql-engine/src/test/java/org/opencds/cqf/cql/execution/CqlErrorsAndMessagingOperatorsTest.java
+++ b/cql-engine/src/test/java/org/opencds/cqf/cql/execution/CqlErrorsAndMessagingOperatorsTest.java
@@ -1,12 +1,13 @@
 package org.opencds.cqf.cql.execution;
 
-import java.util.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.util.ArrayList;
+import java.util.Arrays;
 
 import org.testng.Assert;
 import org.testng.annotations.Test;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
 
 public class CqlErrorsAndMessagingOperatorsTest extends CqlExecutionTestBase {
     @Test

--- a/cql-engine/src/test/java/org/opencds/cqf/cql/execution/CqlExecutionTestBase.java
+++ b/cql-engine/src/test/java/org/opencds/cqf/cql/execution/CqlExecutionTestBase.java
@@ -1,5 +1,18 @@
 package org.opencds.cqf.cql.execution;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.net.URLDecoder;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.xml.bind.JAXBException;
+
 import org.cqframework.cql.cql2elm.CqlTranslator;
 import org.cqframework.cql.cql2elm.CqlTranslatorException;
 import org.cqframework.cql.cql2elm.LibraryManager;
@@ -11,18 +24,6 @@ import org.fhir.ucum.UcumException;
 import org.fhir.ucum.UcumService;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeMethod;
-
-import javax.xml.bind.JAXBException;
-import java.io.File;
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.net.URLDecoder;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Map;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
 
 public abstract class CqlExecutionTestBase {
     static Map<String, Library> libraries = new HashMap<>();

--- a/cql-engine/src/test/java/org/opencds/cqf/cql/execution/CqlExternalFunctionsTest.java
+++ b/cql-engine/src/test/java/org/opencds/cqf/cql/execution/CqlExternalFunctionsTest.java
@@ -1,15 +1,15 @@
 package org.opencds.cqf.cql.execution;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
 import java.util.Arrays;
+
 import javax.xml.bind.JAXBException;
 
 import org.opencds.cqf.cql.data.SystemExternalFunctionProvider;
-import org.opencds.cqf.cql.execution.external.*;
-
+import org.opencds.cqf.cql.execution.external.MyMath;
 import org.testng.annotations.Test;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
 
 public class CqlExternalFunctionsTest extends CqlExecutionTestBase {
 

--- a/cql-engine/src/test/java/org/opencds/cqf/cql/execution/CqlExternalFunctionsTest2.java
+++ b/cql-engine/src/test/java/org/opencds/cqf/cql/execution/CqlExternalFunctionsTest2.java
@@ -1,15 +1,15 @@
 package org.opencds.cqf.cql.execution;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
 import java.util.Arrays;
+
 import javax.xml.bind.JAXBException;
 
 import org.opencds.cqf.cql.data.SystemExternalFunctionProvider;
-import org.opencds.cqf.cql.execution.external.*;
-
+import org.opencds.cqf.cql.execution.external.MyMath2;
 import org.testng.annotations.Test;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
 
 public class CqlExternalFunctionsTest2 extends CqlExecutionTestBase {
 

--- a/cql-engine/src/test/java/org/opencds/cqf/cql/execution/CqlFunctionTests.java
+++ b/cql-engine/src/test/java/org/opencds/cqf/cql/execution/CqlFunctionTests.java
@@ -1,10 +1,10 @@
 package org.opencds.cqf.cql.execution;
 
-import org.testng.annotations.Test;
-
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
+
+import org.testng.annotations.Test;
 
 public class CqlFunctionTests extends CqlExecutionTestBase {
 

--- a/cql-engine/src/test/java/org/opencds/cqf/cql/execution/CqlIntervalOperatorsTest.java
+++ b/cql-engine/src/test/java/org/opencds/cqf/cql/execution/CqlIntervalOperatorsTest.java
@@ -1,16 +1,20 @@
 package org.opencds.cqf.cql.execution;
 
-import org.opencds.cqf.cql.elm.execution.EquivalentEvaluator;
-import org.opencds.cqf.cql.runtime.*;
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 
 import java.math.BigDecimal;
 import java.util.List;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
+import org.opencds.cqf.cql.elm.execution.EquivalentEvaluator;
+import org.opencds.cqf.cql.runtime.DateTime;
+import org.opencds.cqf.cql.runtime.Interval;
+import org.opencds.cqf.cql.runtime.Quantity;
+import org.opencds.cqf.cql.runtime.TemporalHelper;
+import org.opencds.cqf.cql.runtime.Time;
+import org.testng.Assert;
+import org.testng.annotations.Test;
 
 public class CqlIntervalOperatorsTest extends CqlExecutionTestBase {
 

--- a/cql-engine/src/test/java/org/opencds/cqf/cql/execution/CqlLibraryTest.java
+++ b/cql-engine/src/test/java/org/opencds/cqf/cql/execution/CqlLibraryTest.java
@@ -1,14 +1,14 @@
 package org.opencds.cqf.cql.execution;
 
-import org.opencds.cqf.cql.runtime.Code;
-import org.testng.annotations.Test;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import javax.xml.bind.JAXBException;
 
-import static org.hamcrest.MatcherAssert.*;
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import org.opencds.cqf.cql.runtime.Code;
+import org.testng.annotations.Test;
 
 public class CqlLibraryTest extends CqlExecutionTestBase {
 

--- a/cql-engine/src/test/java/org/opencds/cqf/cql/execution/CqlListOperatorsTest.java
+++ b/cql-engine/src/test/java/org/opencds/cqf/cql/execution/CqlListOperatorsTest.java
@@ -1,14 +1,10 @@
 package org.opencds.cqf.cql.execution;
 
-import org.opencds.cqf.cql.elm.execution.EquivalentEvaluator;
-import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
-import org.opencds.cqf.cql.runtime.DateTime;
-import org.opencds.cqf.cql.runtime.TemporalHelper;
-import org.opencds.cqf.cql.runtime.Time;
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isA;
+import static org.hamcrest.Matchers.nullValue;
 
-import javax.xml.bind.JAXBException;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.ArrayList;
@@ -16,8 +12,15 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import javax.xml.bind.JAXBException;
+
+import org.opencds.cqf.cql.elm.execution.EquivalentEvaluator;
+import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
+import org.opencds.cqf.cql.runtime.DateTime;
+import org.opencds.cqf.cql.runtime.TemporalHelper;
+import org.opencds.cqf.cql.runtime.Time;
+import org.testng.Assert;
+import org.testng.annotations.Test;
 
 public class CqlListOperatorsTest extends CqlExecutionTestBase {
 

--- a/cql-engine/src/test/java/org/opencds/cqf/cql/execution/CqlLogicalOperatorsTest.java
+++ b/cql-engine/src/test/java/org/opencds/cqf/cql/execution/CqlLogicalOperatorsTest.java
@@ -1,13 +1,15 @@
 package org.opencds.cqf.cql.execution;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+import javax.xml.bind.JAXBException;
+
 import org.opencds.cqf.cql.elm.execution.AndEvaluator;
 import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-import javax.xml.bind.JAXBException;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
 
 public class CqlLogicalOperatorsTest extends CqlExecutionTestBase {
 

--- a/cql-engine/src/test/java/org/opencds/cqf/cql/execution/CqlNullologicalOperatorsTest.java
+++ b/cql-engine/src/test/java/org/opencds/cqf/cql/execution/CqlNullologicalOperatorsTest.java
@@ -1,19 +1,20 @@
 package org.opencds.cqf.cql.execution;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.math.BigDecimal;
+import java.util.Collections;
+
+import javax.xml.bind.JAXBException;
+
 import org.opencds.cqf.cql.elm.execution.EquivalentEvaluator;
 import org.opencds.cqf.cql.runtime.DateTime;
 import org.opencds.cqf.cql.runtime.TemporalHelper;
 import org.opencds.cqf.cql.runtime.Time;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-
-import javax.xml.bind.JAXBException;
-import java.math.BigDecimal;
-import java.util.Collections;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
 
 public class CqlNullologicalOperatorsTest extends CqlExecutionTestBase {
 

--- a/cql-engine/src/test/java/org/opencds/cqf/cql/execution/CqlQueryTests.java
+++ b/cql-engine/src/test/java/org/opencds/cqf/cql/execution/CqlQueryTests.java
@@ -1,12 +1,12 @@
 package org.opencds.cqf.cql.execution;
 
+import java.util.Arrays;
+import java.util.List;
+
 import org.opencds.cqf.cql.elm.execution.EquivalentEvaluator;
 import org.opencds.cqf.cql.runtime.Tuple;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-
-import java.util.Arrays;
-import java.util.List;
 
 public class CqlQueryTests extends CqlExecutionTestBase
 {

--- a/cql-engine/src/test/java/org/opencds/cqf/cql/execution/CqlStringOperatorsTest.java
+++ b/cql-engine/src/test/java/org/opencds/cqf/cql/execution/CqlStringOperatorsTest.java
@@ -1,12 +1,17 @@
 package org.opencds.cqf.cql.execution;
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
-import javax.xml.bind.JAXBException;
-import java.util.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+
+import javax.xml.bind.JAXBException;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
 
 public class CqlStringOperatorsTest extends CqlExecutionTestBase {
 

--- a/cql-engine/src/test/java/org/opencds/cqf/cql/execution/CqlTestSuite.java
+++ b/cql-engine/src/test/java/org/opencds/cqf/cql/execution/CqlTestSuite.java
@@ -1,5 +1,20 @@
 package org.opencds.cqf.cql.execution;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.StringReader;
+import java.math.BigDecimal;
+import java.net.URLDecoder;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+
+import javax.xml.bind.JAXBException;
+
 import org.cqframework.cql.cql2elm.CqlTranslator;
 import org.cqframework.cql.cql2elm.CqlTranslatorException;
 import org.cqframework.cql.cql2elm.LibraryManager;
@@ -11,25 +26,19 @@ import org.cqframework.cql.elm.tracking.TrackBack;
 import org.fhir.ucum.UcumEssenceService;
 import org.fhir.ucum.UcumException;
 import org.fhir.ucum.UcumService;
-import org.opencds.cqf.cql.runtime.*;
+import org.opencds.cqf.cql.runtime.Code;
+import org.opencds.cqf.cql.runtime.Concept;
+import org.opencds.cqf.cql.runtime.CqlList;
+import org.opencds.cqf.cql.runtime.DateTime;
+import org.opencds.cqf.cql.runtime.Interval;
+import org.opencds.cqf.cql.runtime.Quantity;
+import org.opencds.cqf.cql.runtime.TemporalHelper;
+import org.opencds.cqf.cql.runtime.Time;
+import org.opencds.cqf.cql.runtime.Tuple;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-
-import javax.xml.bind.JAXBException;
-import java.io.File;
-import java.io.IOException;
-import java.io.StringReader;
-import java.math.BigDecimal;
-import java.net.URLDecoder;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
 
 public class CqlTestSuite {
 

--- a/cql-engine/src/test/java/org/opencds/cqf/cql/execution/CqlTypeOperatorsTest.java
+++ b/cql-engine/src/test/java/org/opencds/cqf/cql/execution/CqlTypeOperatorsTest.java
@@ -1,18 +1,25 @@
 package org.opencds.cqf.cql.execution;
 
-import org.opencds.cqf.cql.elm.execution.AsEvaluator;
-import org.opencds.cqf.cql.elm.execution.EquivalentEvaluator;
-import org.opencds.cqf.cql.exception.InvalidCast;
-import org.opencds.cqf.cql.runtime.*;
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
-import javax.xml.bind.JAXBException;
 import java.math.BigDecimal;
 import java.time.format.DateTimeParseException;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import javax.xml.bind.JAXBException;
+
+import org.opencds.cqf.cql.elm.execution.AsEvaluator;
+import org.opencds.cqf.cql.elm.execution.EquivalentEvaluator;
+import org.opencds.cqf.cql.exception.InvalidCast;
+import org.opencds.cqf.cql.runtime.Code;
+import org.opencds.cqf.cql.runtime.Concept;
+import org.opencds.cqf.cql.runtime.DateTime;
+import org.opencds.cqf.cql.runtime.Quantity;
+import org.opencds.cqf.cql.runtime.TemporalHelper;
+import org.opencds.cqf.cql.runtime.Time;
+import org.opencds.cqf.cql.runtime.Tuple;
+import org.testng.Assert;
+import org.testng.annotations.Test;
 
 public class CqlTypeOperatorsTest extends CqlExecutionTestBase {
 

--- a/cql-engine/src/test/java/org/opencds/cqf/cql/execution/CqlTypesTest.java
+++ b/cql-engine/src/test/java/org/opencds/cqf/cql/execution/CqlTypesTest.java
@@ -1,20 +1,27 @@
 package org.opencds.cqf.cql.execution;
 
-import org.opencds.cqf.cql.elm.execution.EquivalentEvaluator;
-import org.opencds.cqf.cql.exception.InvalidDateTime;
-import org.opencds.cqf.cql.runtime.*;
-import org.testng.Assert;
-import org.testng.annotations.Test;
-
-import javax.xml.bind.JAXBException;
-import java.math.BigDecimal;
-import java.time.format.DateTimeParseException;
-import java.util.Arrays;
-import java.util.HashMap;
-
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.HashMap;
+
+import javax.xml.bind.JAXBException;
+
+import org.opencds.cqf.cql.elm.execution.EquivalentEvaluator;
+import org.opencds.cqf.cql.exception.InvalidDateTime;
+import org.opencds.cqf.cql.runtime.Code;
+import org.opencds.cqf.cql.runtime.Concept;
+import org.opencds.cqf.cql.runtime.DateTime;
+import org.opencds.cqf.cql.runtime.Interval;
+import org.opencds.cqf.cql.runtime.Quantity;
+import org.opencds.cqf.cql.runtime.TemporalHelper;
+import org.opencds.cqf.cql.runtime.Time;
+import org.opencds.cqf.cql.runtime.Tuple;
+import org.testng.Assert;
+import org.testng.annotations.Test;
 
 public class CqlTypesTest extends CqlExecutionTestBase {
 

--- a/cql-engine/src/test/java/org/opencds/cqf/cql/execution/CqlValueLiteralsAndSelectorsTest.java
+++ b/cql-engine/src/test/java/org/opencds/cqf/cql/execution/CqlValueLiteralsAndSelectorsTest.java
@@ -1,15 +1,18 @@
 package org.opencds.cqf.cql.execution;
 
-import org.junit.Assert;
-import org.opencds.cqf.cql.exception.CqlException;
-import org.testng.annotations.Test;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.comparesEqualTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 
-import javax.xml.bind.JAXBException;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import javax.xml.bind.JAXBException;
+
+import org.junit.Assert;
+import org.opencds.cqf.cql.exception.CqlException;
+import org.testng.annotations.Test;
 
 public class CqlValueLiteralsAndSelectorsTest extends CqlExecutionTestBase {
 

--- a/cql-engine/src/test/java/org/opencds/cqf/cql/execution/DateComparatorTest.java
+++ b/cql-engine/src/test/java/org/opencds/cqf/cql/execution/DateComparatorTest.java
@@ -1,12 +1,9 @@
 package org.opencds.cqf.cql.execution;
 
-import org.opencds.cqf.cql.elm.execution.EquivalentEvaluator;
-import org.opencds.cqf.cql.runtime.*;
-import org.testng.Assert;
-import org.testng.annotations.Test;
-
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+
+import org.testng.annotations.Test;
 
 public class DateComparatorTest extends CqlExecutionTestBase {
     @Test

--- a/cql-engine/src/test/java/org/opencds/cqf/cql/execution/DateOrDateTimeInNullIntervalTest.java
+++ b/cql-engine/src/test/java/org/opencds/cqf/cql/execution/DateOrDateTimeInNullIntervalTest.java
@@ -1,13 +1,10 @@
 package org.opencds.cqf.cql.execution;
 
-import org.opencds.cqf.cql.elm.execution.EquivalentEvaluator;
-import org.opencds.cqf.cql.runtime.*;
-import org.testng.Assert;
-import org.testng.annotations.Test;
-
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
+
+import org.testng.annotations.Test;
 
 public class DateOrDateTimeInNullIntervalTest extends CqlExecutionTestBase {
     @Test

--- a/cql-engine/src/test/java/org/opencds/cqf/cql/execution/ElmTests.java
+++ b/cql-engine/src/test/java/org/opencds/cqf/cql/execution/ElmTests.java
@@ -1,13 +1,14 @@
 package org.opencds.cqf.cql.execution;
 
+import java.io.IOException;
+import java.util.List;
+
+import javax.xml.bind.JAXBException;
+
 import org.cqframework.cql.elm.execution.Library;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-
-import javax.xml.bind.JAXBException;
-import java.io.IOException;
-import java.util.List;
 
 public class ElmTests {
 

--- a/cql-engine/src/test/java/org/opencds/cqf/cql/execution/InMemoryLibrarySourceProvider.java
+++ b/cql-engine/src/test/java/org/opencds/cqf/cql/execution/InMemoryLibrarySourceProvider.java
@@ -4,7 +4,6 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.Map;
 
-
 import org.cqframework.cql.cql2elm.LibrarySourceProvider;
 
 public class InMemoryLibrarySourceProvider implements LibrarySourceProvider {

--- a/cql-engine/src/test/java/org/opencds/cqf/cql/execution/IncludedCodeRefTest.java
+++ b/cql-engine/src/test/java/org/opencds/cqf/cql/execution/IncludedCodeRefTest.java
@@ -1,13 +1,12 @@
 package org.opencds.cqf.cql.execution;
 
-import org.testng.annotations.Test;
-
-
-import static org.hamcrest.MatcherAssert.*;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertNotNull;
 
 import org.opencds.cqf.cql.runtime.Code;
+import org.testng.annotations.Test;
 
 public class IncludedCodeRefTest extends CqlExecutionTestBase {
     @Test

--- a/cql-engine/src/test/java/org/opencds/cqf/cql/execution/Issue208.java
+++ b/cql-engine/src/test/java/org/opencds/cqf/cql/execution/Issue208.java
@@ -1,11 +1,10 @@
 package org.opencds.cqf.cql.execution;
 
+import java.util.List;
+
 import org.opencds.cqf.cql.elm.execution.EquivalentEvaluator;
-import org.opencds.cqf.cql.runtime.*;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-
-import java.util.List;
 
 public class Issue208 extends CqlExecutionTestBase {
     @Test

--- a/cql-engine/src/test/java/org/opencds/cqf/cql/execution/Issue213.java
+++ b/cql-engine/src/test/java/org/opencds/cqf/cql/execution/Issue213.java
@@ -1,14 +1,4 @@
 package org.opencds.cqf.cql.execution;
-import org.opencds.cqf.cql.elm.execution.EquivalentEvaluator;
-import org.opencds.cqf.cql.runtime.*;
-import org.testng.Assert;
-import org.testng.annotations.Test;
-
-import java.math.BigDecimal;
-import java.util.List;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
 
 public class Issue213 extends CqlExecutionTestBase {
     // @Test

--- a/cql-engine/src/test/java/org/opencds/cqf/cql/execution/Issue223.java
+++ b/cql-engine/src/test/java/org/opencds/cqf/cql/execution/Issue223.java
@@ -1,11 +1,11 @@
 package org.opencds.cqf.cql.execution;
 
-import org.testng.annotations.Test;
-
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 import java.util.List;
+
+import org.testng.annotations.Test;
 
 public class Issue223 extends CqlExecutionTestBase {
     @Test

--- a/cql-engine/src/test/java/org/opencds/cqf/cql/execution/Issue33.java
+++ b/cql-engine/src/test/java/org/opencds/cqf/cql/execution/Issue33.java
@@ -1,11 +1,13 @@
 package org.opencds.cqf.cql.execution;
 
+import java.math.BigDecimal;
+
 import org.opencds.cqf.cql.elm.execution.EquivalentEvaluator;
-import org.opencds.cqf.cql.runtime.*;
+import org.opencds.cqf.cql.runtime.DateTime;
+import org.opencds.cqf.cql.runtime.Interval;
+import org.opencds.cqf.cql.runtime.TemporalHelper;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-
-import java.math.BigDecimal;
 
 public class Issue33 extends CqlExecutionTestBase {
     @Test

--- a/cql-engine/src/test/java/org/opencds/cqf/cql/execution/Issue39.java
+++ b/cql-engine/src/test/java/org/opencds/cqf/cql/execution/Issue39.java
@@ -1,9 +1,9 @@
 package org.opencds.cqf.cql.execution;
 
-import org.testng.annotations.Test;
-
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+
+import org.testng.annotations.Test;
 
 public class Issue39 extends CqlExecutionTestBase {
     @Test

--- a/cql-engine/src/test/java/org/opencds/cqf/cql/execution/LetClauseOutsideQueryContextTest.java
+++ b/cql-engine/src/test/java/org/opencds/cqf/cql/execution/LetClauseOutsideQueryContextTest.java
@@ -1,11 +1,10 @@
 package org.opencds.cqf.cql.execution;
 
+import java.util.List;
+
 import org.opencds.cqf.cql.elm.execution.EquivalentEvaluator;
-import org.opencds.cqf.cql.runtime.*;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-
-import java.util.List;
 
 public class LetClauseOutsideQueryContextTest extends CqlExecutionTestBase {
     @Test

--- a/cql-engine/src/test/java/org/opencds/cqf/cql/execution/SortDescendingTest.java
+++ b/cql-engine/src/test/java/org/opencds/cqf/cql/execution/SortDescendingTest.java
@@ -1,13 +1,10 @@
 package org.opencds.cqf.cql.execution;
 
-import org.opencds.cqf.cql.elm.execution.EquivalentEvaluator;
-import org.opencds.cqf.cql.runtime.*;
-import org.testng.Assert;
-import org.testng.annotations.Test;
-
 import java.util.List;
 
-import static org.hamcrest.MatcherAssert.assertThat;
+import org.opencds.cqf.cql.elm.execution.EquivalentEvaluator;
+import org.testng.Assert;
+import org.testng.annotations.Test;
 
 public class SortDescendingTest extends CqlExecutionTestBase {
     @Test

--- a/cql-engine/src/test/java/org/opencds/cqf/cql/execution/TestLibraryLoader.java
+++ b/cql-engine/src/test/java/org/opencds/cqf/cql/execution/TestLibraryLoader.java
@@ -1,27 +1,26 @@
 package org.opencds.cqf.cql.execution;
 
-import org.cqframework.cql.cql2elm.CqlTranslator;
-import org.cqframework.cql.cql2elm.CqlTranslatorException;
-import org.cqframework.cql.cql2elm.LibraryManager;
-import org.cqframework.cql.cql2elm.CqlTranslatorException.ErrorSeverity;
-import org.cqframework.cql.cql2elm.LibraryBuilder.SignatureLevel;
-import org.cqframework.cql.elm.execution.Library;
-import org.cqframework.cql.elm.execution.VersionedIdentifier;
-import org.hl7.elm.r1.ObjectFactory;
-import org.opencds.cqf.cql.execution.CqlLibraryReader;
-import org.opencds.cqf.cql.execution.LibraryLoader;
-
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Marshaller;
 import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
-import org.hl7.cql_annotations.r1.Annotation;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Marshaller;
+
+import org.cqframework.cql.cql2elm.CqlTranslator;
+import org.cqframework.cql.cql2elm.CqlTranslatorException;
+import org.cqframework.cql.cql2elm.CqlTranslatorException.ErrorSeverity;
+import org.cqframework.cql.cql2elm.LibraryBuilder.SignatureLevel;
+import org.cqframework.cql.cql2elm.LibraryManager;
+import org.cqframework.cql.elm.execution.Library;
+import org.cqframework.cql.elm.execution.VersionedIdentifier;
+import org.hl7.cql_annotations.r1.Annotation;
+import org.hl7.elm.r1.ObjectFactory;
 
 public class TestLibraryLoader implements LibraryLoader {
 

--- a/cql-engine/src/test/java/org/opencds/cqf/cql/execution/TestLibrarySourceProvider.java
+++ b/cql-engine/src/test/java/org/opencds/cqf/cql/execution/TestLibrarySourceProvider.java
@@ -1,9 +1,9 @@
 package org.opencds.cqf.cql.execution;
 
+import java.io.InputStream;
+
 import org.cqframework.cql.cql2elm.LibrarySourceProvider;
 import org.hl7.elm.r1.VersionedIdentifier;
-
-import java.io.InputStream;
 
 public class TestLibrarySourceProvider implements LibrarySourceProvider {
     @Override


### PR DESCRIPTION
* Fixes a few spelling errors.
* Usings organized globally
* Partially resolves cqframework/clinical_quality_language#985 

Fixes around 200 warnings.