### PR TITLE
Parameterized raw types and other general warning cleanup

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,10 +15,18 @@
         "BACKBONEELEMENT",
         "Codeable",
         "DOMAINRESOURCE",
+        "Descendents",
         "Dstu",
         "Fhir",
         "SNOMED",
+        "Schuler",
+        "elems",
+        "fhirpath",
         "hapi",
-        "ucum"
+        "hardcoding",
+        "indexth",
+        "inputfile",
+        "ucum",
+        "unpair"
     ]
 }

--- a/cql-engine-fhir/src/main/java/org/opencds/cqf/cql/exception/DataProviderException.java
+++ b/cql-engine-fhir/src/main/java/org/opencds/cqf/cql/exception/DataProviderException.java
@@ -1,6 +1,8 @@
 package org.opencds.cqf.cql.exception;
 
 public class DataProviderException extends CqlException {
+    private static final long serialVersionUID = 1L;
+
     public DataProviderException(String message) {
         super(message);
     }

--- a/cql-engine-fhir/src/main/java/org/opencds/cqf/cql/exception/UnknownElement.java
+++ b/cql-engine-fhir/src/main/java/org/opencds/cqf/cql/exception/UnknownElement.java
@@ -1,6 +1,8 @@
 package org.opencds.cqf.cql.exception;
 
 public class UnknownElement extends DataProviderException {
+    private static final long serialVersionUID = 1L;
+
     public UnknownElement(String message) {
         super(message);
     }

--- a/cql-engine-fhir/src/main/java/org/opencds/cqf/cql/exception/UnknownPath.java
+++ b/cql-engine-fhir/src/main/java/org/opencds/cqf/cql/exception/UnknownPath.java
@@ -1,6 +1,8 @@
 package org.opencds.cqf.cql.exception;
 
 public class UnknownPath extends DataProviderException {
+    private static final long serialVersionUID = 1L;
+
     public UnknownPath(String message) {
         super(message);
     }

--- a/cql-engine-fhir/src/main/java/org/opencds/cqf/cql/exception/UnknownType.java
+++ b/cql-engine-fhir/src/main/java/org/opencds/cqf/cql/exception/UnknownType.java
@@ -1,6 +1,8 @@
 package org.opencds.cqf.cql.exception;
 
 public class UnknownType extends DataProviderException {
+    private static final long serialVersionUID = 1L;
+
     public UnknownType(String message) {
         super(message);
     }

--- a/cql-engine-fhir/src/main/java/org/opencds/cqf/cql/terminology/fhir/Dstu3FhirTerminologyProvider.java
+++ b/cql-engine-fhir/src/main/java/org/opencds/cqf/cql/terminology/fhir/Dstu3FhirTerminologyProvider.java
@@ -4,7 +4,6 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 
 import org.hl7.fhir.dstu3.model.BooleanType;
@@ -21,7 +20,6 @@ import org.opencds.cqf.cql.terminology.CodeSystemInfo;
 import org.opencds.cqf.cql.terminology.TerminologyProvider;
 import org.opencds.cqf.cql.terminology.ValueSetInfo;
 
-import ca.uhn.fhir.rest.client.api.IClientInterceptor;
 import ca.uhn.fhir.rest.client.api.IGenericClient;
 import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
 
@@ -42,18 +40,6 @@ public class Dstu3FhirTerminologyProvider implements TerminologyProvider {
 
     public void setFhirClient(IGenericClient fhirClient) {
         this.fhirClient = fhirClient;
-    }
-
-    private IClientInterceptor headerInjectionInterceptor;
-
-    public Dstu3FhirTerminologyProvider withInjectedHeader(String headerKey, String headerValue) {
-        this.headerInjectionInterceptor = new HeaderInjectionInterceptor(headerKey, headerValue);
-        return this;
-    }
-
-    public Dstu3FhirTerminologyProvider withInjectedHeaders(HashMap<String, String> headers) {
-        this.headerInjectionInterceptor = new HeaderInjectionInterceptor(headers);
-        return this;
     }
 
     public IGenericClient getFhirClient() {

--- a/cql-engine-fhir/src/main/java/org/opencds/cqf/cql/terminology/fhir/R4FhirTerminologyProvider.java
+++ b/cql-engine-fhir/src/main/java/org/opencds/cqf/cql/terminology/fhir/R4FhirTerminologyProvider.java
@@ -4,7 +4,6 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 
 import org.hl7.fhir.r4.model.BooleanType;
@@ -21,7 +20,6 @@ import org.opencds.cqf.cql.terminology.CodeSystemInfo;
 import org.opencds.cqf.cql.terminology.TerminologyProvider;
 import org.opencds.cqf.cql.terminology.ValueSetInfo;
 
-import ca.uhn.fhir.rest.client.api.IClientInterceptor;
 import ca.uhn.fhir.rest.client.api.IGenericClient;
 import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
 
@@ -37,18 +35,6 @@ public class R4FhirTerminologyProvider implements TerminologyProvider {
      */
     public R4FhirTerminologyProvider(IGenericClient fhirClient) {
         this.fhirClient = fhirClient;
-    }
-
-    private IClientInterceptor headerInjectionInterceptor;
-
-    public R4FhirTerminologyProvider withInjectedHeader(String headerKey, String headerValue) {
-        this.headerInjectionInterceptor = new HeaderInjectionInterceptor(headerKey, headerValue);
-        return this;
-    }
-
-    public R4FhirTerminologyProvider withInjectedHeaders(HashMap<String, String> headers) {
-        this.headerInjectionInterceptor = new HeaderInjectionInterceptor(headers);
-        return this;
     }
 
     public IGenericClient getFhirClient() {

--- a/cql-engine-fhir/src/main/java/org/opencds/cqf/cql/util/CodeUtil.java
+++ b/cql-engine-fhir/src/main/java/org/opencds/cqf/cql/util/CodeUtil.java
@@ -22,7 +22,7 @@ public class CodeUtil {
     private static List<Code> tryIterableThenConcept(FhirContext fhirContext, Object object) {
         List<Code> codes = new ArrayList<Code>();
         if(object instanceof Iterable) {
-            for (Object concept : (Iterable)object) {
+            for (Object concept : (Iterable<?>)object) {
                 codes.addAll(tryConceptThenCoding(fhirContext, (IBase)concept));
             }
         }
@@ -81,7 +81,7 @@ public class CodeUtil {
         return codes;
     }
 
-    private static BaseRuntimeElementDefinition getElementDefinition(FhirContext fhirContext, String ElementName) {
+    private static BaseRuntimeElementDefinition<?> getElementDefinition(FhirContext fhirContext, String ElementName) {
         BaseRuntimeElementDefinition<?> def = fhirContext.getElementDefinition(ElementName);
         return def;
     }
@@ -118,7 +118,7 @@ public class CodeUtil {
 			throw new IllegalArgumentException("Non-primitive value encountered while trying to access primitive value.");
 		}
 		else {
-			return ((IPrimitiveType)baseValue).getValueAsString();
+			return ((IPrimitiveType<?>)baseValue).getValueAsString();
 		}
 	}
 

--- a/cql-engine-fhir/src/main/java/org/opencds/cqf/cql/util/ValueSetUtil.java
+++ b/cql-engine-fhir/src/main/java/org/opencds/cqf/cql/util/ValueSetUtil.java
@@ -247,7 +247,7 @@ public class ValueSetUtil {
 			throw new IllegalArgumentException("Non-primitive value encountered while trying to access primitive value.");
 		}
 		else {
-			return ((IPrimitiveType)baseValue).getValueAsString();
+			return ((IPrimitiveType<?>)baseValue).getValueAsString();
 		}
 	}
 

--- a/cql-engine-fhir/src/test/java/org/hl7/fhirpath/TestFhirPath.java
+++ b/cql-engine-fhir/src/test/java/org/hl7/fhirpath/TestFhirPath.java
@@ -195,7 +195,7 @@ public class TestFhirPath {
     private Boolean compareResults(Object expectedResult, Object actualResult) {
         // Perform FHIR system-defined type conversions
         if (actualResult instanceof Enumeration) {
-            actualResult = new Code().withCode(((Enumeration) actualResult).getValueAsString());
+            actualResult = new Code().withCode(((Enumeration<?>) actualResult).getValueAsString());
         } else if (actualResult instanceof BooleanType) {
             actualResult = ((BooleanType) actualResult).getValue();
         } else if (actualResult instanceof IntegerType) {
@@ -218,6 +218,7 @@ public class TestFhirPath {
         return EqualEvaluator.equal(expectedResult, actualResult);
     }
 
+    @SuppressWarnings("unchecked")
     private void runStu3Test(org.hl7.fhirpath.tests.Test test) throws UcumException {
         String resourceFilePath = "stu3/input/" + test.getInputfile();
         org.hl7.fhir.dstu3.model.Resource resource = loadResourceFile(resourceFilePath);
@@ -257,7 +258,7 @@ public class TestFhirPath {
             if (result instanceof Iterable) {
                 actualResults = (Iterable<Object>) result;
             } else {
-                List results = new ArrayList<>();
+                List<Object> results = new ArrayList<>();
                 results.add(result);
                 actualResults = results;
             }
@@ -278,7 +279,7 @@ public class TestFhirPath {
         }
     }
 
-
+    @SuppressWarnings("unchecked")
     private void runR4Test(org.hl7.fhirpath.tests.Test test) throws UcumException {
         String resourceFilePath = "r4/input/" + test.getInputfile();
         org.hl7.fhir.r4.model.Resource resource = loadResourceFileR4(resourceFilePath);
@@ -318,7 +319,7 @@ public class TestFhirPath {
             if (result instanceof Iterable) {
                 actualResults = (Iterable<Object>) result;
             } else {
-                List results = new ArrayList<>();
+                List<Object> results = new ArrayList<Object>();
                 results.add(result);
                 actualResults = results;
             }
@@ -435,8 +436,8 @@ public class TestFhirPath {
         // FhirDataProviderStu3().setEndpoint("http://fhirtest.uhn.ca/baseDstu3");
         context.registerDataProvider("http://hl7.org/fhir", provider);
 
-        Object result = context.resolveExpressionRef("TestPeriodToInterval").getExpression().evaluate(context);
         // TODO - fix
+        Object result = context.resolveExpressionRef("TestPeriodToInterval").getExpression().evaluate(context);
         // Assert.assertEquals(((DateTime)((Interval) result).getStart()).getPartial(),
         // new Partial(DateTime.getFields(6), new int[] {2017, 5, 6, 18, 8, 0}));
         // Assert.assertEquals(((DateTime)((Interval) result).getEnd()).getPartial(),
@@ -468,8 +469,8 @@ public class TestFhirPath {
         //BaseFhirDataProvider provider = new FhirDataProviderDstu2();
         context.registerDataProvider("http://hl7.org/fhir", provider);
 
-        Object result = context.resolveExpressionRef("TestPeriodToInterval").getExpression().evaluate(context);
         // TODO - millis shouldn't be populated - issue with DateTime.fromJavaDate(Date date)
+        Object result = context.resolveExpressionRef("TestPeriodToInterval").getExpression().evaluate(context);
 //        Assert.assertEquals(((DateTime)((Interval) result).getStart()).getPartial(), new Partial(DateTime.getFields(7), new int[] {2017, 5, 6, 18, 8, 0, 0}));
 //        Assert.assertEquals(((DateTime)((Interval) result).getEnd()).getPartial(), new Partial(DateTime.getFields(7), new int[] {2017, 5, 6, 19, 8, 0, 0}));
         result = context.resolveExpressionRef("TestToQuantity").getExpression().evaluate(context);

--- a/cql-engine-fhir/src/test/java/org/opencds/cqf/cql/data/fhir/TestFhirDataProviderDstu3.java
+++ b/cql-engine-fhir/src/test/java/org/opencds/cqf/cql/data/fhir/TestFhirDataProviderDstu3.java
@@ -226,6 +226,6 @@ public class TestFhirDataProviderDstu3 extends FhirExecutionTestBase {
         context.setContextValue("Patient", "81ee6581-02b9-44de-b026-7401bf36643a");
 
         Object result = context.resolveExpressionRef("GetProvenance").getExpression().evaluate(context);
-        Assert.assertTrue(result instanceof List && ((List) result).size() == 1);
+        Assert.assertTrue(result instanceof List && ((List<?>) result).size() == 1);
     }
 }

--- a/cql-engine-fhir/src/test/java/org/opencds/cqf/cql/data/fhir/TestFhirExecution.java
+++ b/cql-engine-fhir/src/test/java/org/opencds/cqf/cql/data/fhir/TestFhirExecution.java
@@ -13,7 +13,7 @@ public class TestFhirExecution extends FhirExecutionTestBase {
         Context context = new Context(library);
         context.registerDataProvider("http://hl7.org/fhir", dstu3Provider);
         Object result = context.resolveExpressionRef("testCoalesce").getExpression().evaluate(context);
-        Assert.assertTrue((Integer)((List) result).get(0) == 72);
+        Assert.assertTrue((Integer)((List<?>) result).get(0) == 72);
     }
 
     // @Test

--- a/cql-engine-fhir/src/test/java/org/opencds/cqf/cql/data/fhir/TestFhirLibrary.java
+++ b/cql-engine-fhir/src/test/java/org/opencds/cqf/cql/data/fhir/TestFhirLibrary.java
@@ -43,7 +43,7 @@ public class TestFhirLibrary {
 
         Object result = context.resolveExpressionRef("BP: Systolic").evaluate(context);
         assertThat(result, instanceOf(Iterable.class));
-        for (Object element : (Iterable)result) {
+        for (Object element : (Iterable<?>)result) {
             assertThat(element, instanceOf(Observation.class));
             Observation observation = (Observation)element;
             assertThat(observation.getCode().getCoding().get(0).getCode(), is("8480-6"));
@@ -51,7 +51,7 @@ public class TestFhirLibrary {
 
         result = context.resolveExpressionRef("BP: Diastolic").evaluate(context);
         assertThat(result, instanceOf(Iterable.class));
-        for (Object element : (Iterable)result) {
+        for (Object element : (Iterable<?>)result) {
             assertThat(element, instanceOf(Observation.class));
             Observation observation = (Observation)element;
             assertThat(observation.getCode().getCoding().get(0).getCode(), is("8462-4"));
@@ -78,7 +78,7 @@ public class TestFhirLibrary {
 
         Object result = context.resolveExpressionRef("Breastfeeding Intention Assessment").evaluate(context);
         assertThat(result, instanceOf(Iterable.class));
-        for (Object element : (Iterable)result) {
+        for (Object element : (Iterable<?>)result) {
             assertThat(element, instanceOf(RiskAssessment.class));
         }
     }

--- a/cql-engine-fhir/src/test/java/org/opencds/cqf/cql/model/TestDstu2ModelResolver.java
+++ b/cql-engine-fhir/src/test/java/org/opencds/cqf/cql/model/TestDstu2ModelResolver.java
@@ -31,6 +31,7 @@ import org.testng.annotations.Test;
 public class TestDstu2ModelResolver {
 
     // Couldn't find a way to automatically get the full list of enums.
+    @SuppressWarnings("serial")
     private static List<Class<?>> enums = new ArrayList<Class<?>>() {
         {
             add(AdministrativeGender.class);
@@ -51,7 +52,7 @@ public class TestDstu2ModelResolver {
     };
 
     @Test(expectedExceptions = UnknownType.class)
-    public void resolverThrowsExecptionForUnknownType()
+    public void resolverThrowsExceptionForUnknownType()
     {
         ModelResolver resolver = new Dstu2FhirModelResolver();
         resolver.resolveType("ImpossibleTypeThatDoesntExistAndShouldBlowUp");
@@ -185,7 +186,7 @@ public class TestDstu2ModelResolver {
         
         Patient p = new Patient();
 
-        Object result = resolver.resolvePath(p, "notapath");
+        Object result = resolver.resolvePath(p, "not-a-path");
         assertNull(result);
     }
 }

--- a/cql-engine-fhir/src/test/java/org/opencds/cqf/cql/model/TestDstu3ModelResolver.java
+++ b/cql-engine-fhir/src/test/java/org/opencds/cqf/cql/model/TestDstu3ModelResolver.java
@@ -37,6 +37,7 @@ import org.testng.annotations.Test;
 public class TestDstu3ModelResolver {
 
     // Couldn't find a way to automatically get the full list of enums.
+    @SuppressWarnings("serial")
     private static List<Class<?>> enums = new ArrayList<Class<?>>() {
         {
             add(AbstractType.class);
@@ -60,7 +61,7 @@ public class TestDstu3ModelResolver {
     };
 
     @Test(expectedExceptions = UnknownType.class)
-    public void resolverThrowsExecptionForUnknownType()
+    public void resolverThrowsExceptionForUnknownType()
     {
         ModelResolver resolver = new Dstu3FhirModelResolver();
         resolver.resolveType("ImpossibleTypeThatDoesntExistAndShouldBlowUp");
@@ -103,7 +104,7 @@ public class TestDstu3ModelResolver {
     }
 
     @Test
-    // This tests all the types that are present in the modelinfo
+    // This tests all the types that are present in the ModelInfo.
     public void resolveModelInfoTests() {
         ModelResolver resolver = new Dstu3FhirModelResolver();
         ModelManager mm = new ModelManager();
@@ -115,7 +116,7 @@ public class TestDstu3ModelResolver {
             ClassInfo ci = (ClassInfo)ti;
             if (ci != null) {
                 switch (ci.getBaseType()) {
-                    // Astract classes
+                    // Abstract classes
                     case "FHIR.BackboneElement":
                     case "FHIR.Element": continue;
                 }
@@ -249,7 +250,7 @@ public class TestDstu3ModelResolver {
         
         Patient p = new Patient();
 
-        Object result = resolver.resolvePath(p, "notapath");
+        Object result = resolver.resolvePath(p, "not-a-path");
         assertNull(result);
     }
 }

--- a/cql-engine-fhir/src/test/java/org/opencds/cqf/cql/model/TestR4ModelResolver.java
+++ b/cql-engine-fhir/src/test/java/org/opencds/cqf/cql/model/TestR4ModelResolver.java
@@ -42,6 +42,7 @@ import org.testng.annotations.Test;
 public class TestR4ModelResolver {
 
     // Couldn't find a way to automatically get the full list of enums.
+    @SuppressWarnings("serial")
     private static List<Class<?>> enums = new ArrayList<Class<?>>() {
         {
             add(AbstractType.class);

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/data/SystemDataProvider.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/data/SystemDataProvider.java
@@ -156,9 +156,10 @@ public class SystemDataProvider implements DataProvider {
     public Object createInstance(String typeName) {
         Class<?> clazz = resolveType(typeName);
         try {
-            Object object = clazz.newInstance();
+            Object object = clazz.getDeclaredConstructor().newInstance();
             return object;
-        } catch (InstantiationException | IllegalAccessException e) {
+        } catch (InstantiationException | InvocationTargetException | 
+            ExceptionInInitializerError | IllegalAccessException | SecurityException | NoSuchMethodException e) {
             throw new IllegalArgumentException(String.format("Could not create an instance of class %s.", clazz.getName()));
         }
     }

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/AllTrueEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/AllTrueEvaluator.java
@@ -21,8 +21,8 @@ public class AllTrueEvaluator extends org.cqframework.cql.elm.execution.AllTrue 
         }
 
         if (src instanceof Iterable) {
-            Iterable element = (Iterable)src;
-            Iterator elemsItr = element.iterator();
+            Iterable<?> element = (Iterable<?>)src;
+            Iterator<?> elemsItr = element.iterator();
 
             if (!elemsItr.hasNext()) { // empty list
                 return true;

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/AnyInValueSetEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/AnyInValueSetEvaluator.java
@@ -15,7 +15,7 @@ public class AnyInValueSetEvaluator extends org.cqframework.cql.elm.execution.An
         if (codes instanceof Iterable)
         {
             Object result;
-            for (Object code : (Iterable) codes)
+            for (Object code : (Iterable<?>) codes)
             {
                 result = InValueSetEvaluator.inValueSet(context, code, valueset);
                 if (result instanceof Boolean && (Boolean) result)

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/AnyTrueEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/AnyTrueEvaluator.java
@@ -22,8 +22,8 @@ public class AnyTrueEvaluator extends org.cqframework.cql.elm.execution.AnyTrue 
         }
 
         if (src instanceof Iterable) {
-            Iterable element = (Iterable)src;
-            Iterator elemsItr = element.iterator();
+            Iterable<?> element = (Iterable<?>)src;
+            Iterator<?> elemsItr = element.iterator();
 
             if (!elemsItr.hasNext()) { // empty list
                 return false;

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/AsEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/AsEvaluator.java
@@ -25,7 +25,7 @@ define RuntimeError:
 
 public class AsEvaluator extends org.cqframework.cql.elm.execution.As {
 
-    private Class resolveType(Context context) {
+    private Class<?> resolveType(Context context) {
         if (this.getAsTypeSpecifier() != null) {
             return context.resolveType(this.getAsTypeSpecifier());
         }
@@ -33,7 +33,7 @@ public class AsEvaluator extends org.cqframework.cql.elm.execution.As {
         return context.resolveType(this.getAsType());
     }
 
-    public Object as(Object operand, Class clazz) {
+    public Object as(Object operand, Class<?> clazz) {
 
         if (operand == null) {
             return null;
@@ -53,7 +53,7 @@ public class AsEvaluator extends org.cqframework.cql.elm.execution.As {
     @Override
     protected Object internalEvaluate(Context context) {
         Object operand = getOperand().evaluate(context);
-        Class clazz = resolveType(context);
+        Class<?> clazz = resolveType(context);
         return as(operand, clazz);
     }
 }

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/AvgEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/AvgEvaluator.java
@@ -25,7 +25,7 @@ public class AvgEvaluator extends org.cqframework.cql.elm.execution.Avg {
         }
 
         if (source instanceof Iterable) {
-            Iterable elements = (Iterable) source;
+            Iterable<?> elements = (Iterable<?>) source;
             Object avg = null;
             int size = 1;
 

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/ChildrenEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/ChildrenEvaluator.java
@@ -70,6 +70,7 @@ public class ChildrenEvaluator extends org.cqframework.cql.elm.execution.Childre
         list = (List<Object>) FlattenEvaluator.flatten(list);
     }
 
+    @SuppressWarnings("unchecked")
     public static Object children(Object source) {
         if (source == null) {
             return null;

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/CoalesceEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/CoalesceEvaluator.java
@@ -27,7 +27,7 @@ public class CoalesceEvaluator extends org.cqframework.cql.elm.execution.Coalesc
 
                 if (operand instanceof Iterable && operands.size() == 1) {
 
-                    for (Object obj : ((Iterable) operand)) {
+                    for (Object obj : ((Iterable<?>) operand)) {
                         if (obj != null) {
                             return obj;
                         }

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/CollapseEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/CollapseEvaluator.java
@@ -139,6 +139,7 @@ public class CollapseEvaluator extends org.cqframework.cql.elm.execution.Collaps
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     protected Object internalEvaluate(Context context)
     {
         Iterable<Interval> list = (Iterable<Interval>) getOperand().get(0).evaluate(context);

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/CombineEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/CombineEvaluator.java
@@ -24,7 +24,7 @@ public class CombineEvaluator extends org.cqframework.cql.elm.execution.Combine 
         else {
             if (source instanceof Iterable) {
                 StringBuffer buffer = new StringBuffer("");
-                Iterator iterator = ((Iterable) source).iterator();
+                Iterator<?> iterator = ((Iterable<?>) source).iterator();
                 boolean first = true;
 
                 while (iterator.hasNext()) {

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/ConvertEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/ConvertEvaluator.java
@@ -1,5 +1,7 @@
 package org.opencds.cqf.cql.elm.execution;
 
+import java.lang.reflect.InvocationTargetException;
+
 import org.opencds.cqf.cql.exception.InvalidConversion;
 import org.opencds.cqf.cql.execution.Context;
 
@@ -38,24 +40,25 @@ For specific semantics for each conversion, refer to the explicit conversion ope
 
 public class ConvertEvaluator extends org.cqframework.cql.elm.execution.Convert {
 
-    private Class resolveType(Context context) {
+    private Class<?> resolveType(Context context) {
         if (this.getToTypeSpecifier() != null) {
             return context.resolveType(this.getToTypeSpecifier());
         }
         return context.resolveType(this.getToType());
     }
 
-    private static Object convert(Object operand, Class type) {
+    private static Object convert(Object operand, Class<?> type) {
         if (operand == null) {
             return null;
         }
 
         try {
             if (type.isInstance(operand)) {
-                Class cls = operand.getClass();
-                return cls.newInstance();
+                Class<?> cls = operand.getClass();
+                return cls.getDeclaredConstructor().newInstance();
             }
-        } catch (InstantiationException | IllegalAccessException e) {
+        } catch (InstantiationException | InvocationTargetException | 
+            ExceptionInInitializerError | IllegalAccessException | SecurityException | NoSuchMethodException e) {
             throw new InvalidConversion("Error during conversion: " + e.getMessage());
         }
 
@@ -65,7 +68,7 @@ public class ConvertEvaluator extends org.cqframework.cql.elm.execution.Convert 
     @Override
     protected Object internalEvaluate(Context context) {
         Object operand = getOperand().evaluate(context);
-        Class type = resolveType(context);
+        Class<?> type = resolveType(context);
 
         return convert(operand, type);
     }

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/CountEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/CountEvaluator.java
@@ -24,8 +24,8 @@ public class CountEvaluator extends org.cqframework.cql.elm.execution.Count {
         Integer size = 0;
 
         if (source instanceof Iterable) {
-            Iterable element = (Iterable)source;
-            Iterator itr = element.iterator();
+            Iterable<?> element = (Iterable<?>)source;
+            Iterator<?> itr = element.iterator();
 
             if (!itr.hasNext()) { // empty list
                 return size;

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/DescendentsEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/DescendentsEvaluator.java
@@ -21,7 +21,7 @@ public class DescendentsEvaluator extends org.cqframework.cql.elm.execution.Desc
 
     public static Object getDescendents(Object source) {
         if (source instanceof Iterable) {
-            for (Object element : (Iterable) source) {
+            for (Object element : (Iterable<?>) source) {
                 descendents.add(getDescendents(element));
             }
         }

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/DistinctEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/DistinctEvaluator.java
@@ -17,7 +17,7 @@ If the argument is null, the result is null.
 public class DistinctEvaluator extends org.cqframework.cql.elm.execution.Distinct
 {
 
-    public static List<Object> distinct(Iterable source)
+    public static List<Object> distinct(Iterable<?> source)
     {
         if (source == null)
         {
@@ -47,6 +47,6 @@ public class DistinctEvaluator extends org.cqframework.cql.elm.execution.Distinc
     protected Object internalEvaluate(Context context)
     {
         Object value = this.getOperand().evaluate(context);
-        return distinct((Iterable)value);
+        return distinct((Iterable<?>)value);
     }
 }

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/EqualEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/EqualEvaluator.java
@@ -60,7 +60,7 @@ public class EqualEvaluator extends org.cqframework.cql.elm.execution.Equal {
         }
 
         else if (left instanceof Iterable && right instanceof Iterable) {
-            return CqlList.equal((Iterable) left, (Iterable) right);
+            return CqlList.equal((Iterable<?>) left, (Iterable<?>) right);
         }
 
         else if (left instanceof CqlType && right instanceof CqlType) {

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/EquivalentEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/EquivalentEvaluator.java
@@ -67,7 +67,7 @@ public class EquivalentEvaluator extends org.cqframework.cql.elm.execution.Equiv
         }
 
         if (left instanceof Iterable) {
-            return CqlList.equivalent((Iterable) left, (Iterable) right);
+            return CqlList.equivalent((Iterable<?>) left, (Iterable<?>) right);
         }
 
         else if (left instanceof CqlType) {

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/ExceptEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/ExceptEvaluator.java
@@ -115,8 +115,8 @@ public class ExceptEvaluator extends org.cqframework.cql.elm.execution.Except
 
         else if (left instanceof Iterable)
         {
-            Iterable leftArr = (Iterable)left;
-            Iterable rightArr = (Iterable)right;
+            Iterable<?> leftArr = (Iterable<?>)left;
+            Iterable<?> rightArr = (Iterable<?>)right;
 
             List<Object> result = new ArrayList<>();
             Boolean in;

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/ExistsEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/ExistsEvaluator.java
@@ -12,6 +12,7 @@ If the argument is null, the result is null.
 
 public class ExistsEvaluator extends org.cqframework.cql.elm.execution.Exists {
 
+    @SuppressWarnings("unchecked")
     public static Object exists(Object operand) {
         Iterable<Object> value = (Iterable<Object>) operand;
 

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/ExpandEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/ExpandEvaluator.java
@@ -217,6 +217,7 @@ public class ExpandEvaluator extends org.cqframework.cql.elm.execution.Expand
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     protected Object internalEvaluate(Context context)
     {
         Iterable<Interval> list = (Iterable<Interval>) getOperand().get(0).evaluate(context);

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/FilterEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/FilterEvaluator.java
@@ -21,7 +21,7 @@ public class FilterEvaluator extends Filter {
 
         if (source instanceof Iterable) {
 
-            for (Object obj : (List) source) {
+            for (Object obj : (List<?>) source) {
                 try {
                     // Hmmm... This is hard without the alias.
                     // TODO: verify this works for all cases -> will scope always be present?

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/FirstEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/FirstEvaluator.java
@@ -17,7 +17,7 @@ public class FirstEvaluator extends org.cqframework.cql.elm.execution.First {
             return null;
         }
 
-        for (Object element : (Iterable) source) {
+        for (Object element : (Iterable<?>) source) {
             return element;
         }
 

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/FlattenEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/FlattenEvaluator.java
@@ -14,15 +14,15 @@ The flatten operator flattens a list of lists into a single list.
 
 public class FlattenEvaluator extends org.cqframework.cql.elm.execution.Flatten {
 
-    public static Object flatten(Object operand) {
+    public static List<Object> flatten(Object operand) {
         if (operand == null) {
             return null;
         }
 
         if (operand instanceof Iterable) {
             List<Object> resultList = new ArrayList<>();
-            for (Object element : (Iterable) operand) {
-                for (Object subElement : (Iterable) element) {
+            for (Object element : (Iterable<?>) operand) {
+                for (Object subElement : (Iterable<?>) element) {
                     resultList.add(subElement);
                 }
             }

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/ForEachEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/ForEachEvaluator.java
@@ -14,7 +14,7 @@ public class ForEachEvaluator extends org.cqframework.cql.elm.execution.ForEach 
         }
 
         List<Object> retVal = new ArrayList<>();
-        for (Object o : (Iterable) source) {
+        for (Object o : (Iterable<?>) source) {
             retVal.add(context.resolvePath(o, element.toString()));
         }
         return retVal;

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/GeometricMeanEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/GeometricMeanEvaluator.java
@@ -24,7 +24,7 @@ If the source is null, the result is null.
 
 public class GeometricMeanEvaluator extends org.cqframework.cql.elm.execution.GeometricMean {
 
-    public static BigDecimal geometricMean(Iterable source) {
+    public static BigDecimal geometricMean(Iterable<?> source) {
         if (source == null) {
             return null;
         }
@@ -51,6 +51,6 @@ public class GeometricMeanEvaluator extends org.cqframework.cql.elm.execution.Ge
 
     @Override
     protected Object internalEvaluate(Context context) {
-        return geometricMean((Iterable) getSource().evaluate(context));
+        return geometricMean((Iterable<?>) getSource().evaluate(context));
     }
 }

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/InEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/InEvaluator.java
@@ -42,7 +42,7 @@ public class InEvaluator extends org.cqframework.cql.elm.execution.In
 
         if (right instanceof Iterable)
         {
-            return listIn(left, (Iterable) right);
+            return listIn(left, (Iterable<?>) right);
         }
 
         else if (right instanceof Interval)
@@ -82,17 +82,17 @@ public class InEvaluator extends org.cqframework.cql.elm.execution.In
                 pointSameOrAfterStart = SameOrAfterEvaluator.sameOrAfter(left, rightStart, precision);
             }
 
-            Boolean pointSamedOrBeforeEnd;
+            Boolean pointSameOrBeforeEnd;
             if (rightEnd == null && right.getHighClosed())
             {
-                pointSamedOrBeforeEnd = true;
+                pointSameOrBeforeEnd = true;
             }
             else
             {
-                pointSamedOrBeforeEnd = SameOrBeforeEvaluator.sameOrBefore(left, rightEnd, precision);
+                pointSameOrBeforeEnd = SameOrBeforeEvaluator.sameOrBefore(left, rightEnd, precision);
             }
 
-            return AndEvaluator.and(pointSameOrAfterStart, pointSamedOrBeforeEnd);
+            return AndEvaluator.and(pointSameOrAfterStart, pointSameOrBeforeEnd);
         }
 
         else if (AnyTrueEvaluator.anyTrue(Arrays.asList(EqualEvaluator.equal(left, right.getStart()), EqualEvaluator.equal(left, right.getEnd()))))
@@ -127,7 +127,7 @@ public class InEvaluator extends org.cqframework.cql.elm.execution.In
         return AndEvaluator.and(greaterOrEqual, lessOrEqual);
     }
 
-    private static Boolean listIn(Object left, Iterable right)
+    private static Boolean listIn(Object left, Iterable<?> right)
     {
         Boolean isEqual;
         for (Object element : right)

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/IncludedInEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/IncludedInEvaluator.java
@@ -18,7 +18,7 @@ The included in operator for intervals returns true if the first interval is com
 This operator uses the semantics described in the Start and End operators to determine interval boundaries.
 If precision is specified and the point type is a date/time type, comparisons used in the operation are performed at the specified precision.
 If either argument is null, the result is null.
-Note that during is a synonym for included in and may be used to invoke the same operation whever included in may appear.
+Note that during is a synonym for included in and may be used to invoke the same operation whenever included in may appear.
 
 *** NOTES FOR LIST ***
 included in(left List<T>, right list<T>) Boolean
@@ -37,7 +37,7 @@ public class IncludedInEvaluator extends org.cqframework.cql.elm.execution.Inclu
             return intervalIncludedIn((Interval) left, (Interval) right, precision);
         }
         if (left instanceof Iterable && right instanceof Iterable) {
-            return listIncludedIn((Iterable) left, (Iterable) right);
+            return listIncludedIn((Iterable<?>) left, (Iterable<?>) right);
         }
 
         throw new InvalidOperatorArgument(
@@ -89,7 +89,7 @@ public class IncludedInEvaluator extends org.cqframework.cql.elm.execution.Inclu
         );
     }
 
-    public static Boolean listIncludedIn(Iterable left, Iterable right) {
+    public static Boolean listIncludedIn(Iterable<?> left, Iterable<?> right) {
         if (left == null) {
             return true;
         }
@@ -122,13 +122,13 @@ public class IncludedInEvaluator extends org.cqframework.cql.elm.execution.Inclu
         if (left == null) {
             return right instanceof Interval
                     ? intervalIncludedIn(null, (Interval) right, precision)
-                    : listIncludedIn(null, (Iterable) right);
+                    : listIncludedIn(null, (Iterable<?>) right);
         }
 
         if (right == null) {
             return left instanceof Interval
                     ? intervalIncludedIn((Interval) left, null, precision)
-                    : listIncludedIn((Iterable) left, null);
+                    : listIncludedIn((Iterable<?>) left, null);
         }
 
         return includedIn(left, right, precision);

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/IncludesEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/IncludesEvaluator.java
@@ -53,13 +53,13 @@ public class IncludesEvaluator extends org.cqframework.cql.elm.execution.Include
         if (left == null) {
             return right instanceof Interval
                     ? IncludedInEvaluator.intervalIncludedIn((Interval) right, null, precision)
-                    : IncludedInEvaluator.listIncludedIn((Iterable) right, null);
+                    : IncludedInEvaluator.listIncludedIn((Iterable<?>) right, null);
         }
 
         if (right == null) {
             return left instanceof Interval
                     ? IncludedInEvaluator.intervalIncludedIn(null, (Interval) left, precision)
-                    : IncludedInEvaluator.listIncludedIn(null, (Iterable) left);
+                    : IncludedInEvaluator.listIncludedIn(null, (Iterable<?>) left);
         }
 
         return includes(left, right, precision);

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/IndexOfEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/IndexOfEvaluator.java
@@ -22,7 +22,7 @@ public class IndexOfEvaluator extends org.cqframework.cql.elm.execution.IndexOf 
         int index = -1;
         boolean nullSwitch = false;
 
-        for (Object element : (Iterable)source) {
+        for (Object element : (Iterable<?>)source) {
             index++;
             Boolean equiv = EquivalentEvaluator.equivalent(element, elementToFind);
 

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/IndexerEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/IndexerEvaluator.java
@@ -41,7 +41,7 @@ public class IndexerEvaluator extends org.cqframework.cql.elm.execution.Indexer 
         if (left instanceof Iterable) {
             if (right instanceof Integer) {
                 int index = -1;
-                for (Object element : (Iterable)left) {
+                for (Object element : (Iterable<?>)left) {
                     index++;
                     if ((Integer)right == index) {
                         return element;

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/IntersectEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/IntersectEvaluator.java
@@ -94,8 +94,8 @@ public class IntersectEvaluator extends org.cqframework.cql.elm.execution.Inters
 
         else if (left instanceof Iterable)
         {
-            Iterable leftArr = (Iterable)left;
-            Iterable rightArr = (Iterable)right;
+            Iterable<?> leftArr = (Iterable<?>)left;
+            Iterable<?> rightArr = (Iterable<?>)right;
 
             List<Object> result = new ArrayList<>();
             Boolean in;

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/IsEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/IsEvaluator.java
@@ -12,7 +12,7 @@ If the run-time type of the argument is of the type being tested, the result of 
 
 public class IsEvaluator extends org.cqframework.cql.elm.execution.Is {
 
-    public static Object is(Class type, Object operand) {
+    public static Object is(Class<?> type, Object operand) {
         if (operand == null) {
             return null;
         }
@@ -20,7 +20,7 @@ public class IsEvaluator extends org.cqframework.cql.elm.execution.Is {
         return type.isAssignableFrom(operand.getClass());
     }
 
-  private Class resolveType(Context context) {
+  private Class<?> resolveType(Context context) {
       if (this.getIsTypeSpecifier() != null) {
           return context.resolveType(this.getIsTypeSpecifier());
       }
@@ -31,7 +31,7 @@ public class IsEvaluator extends org.cqframework.cql.elm.execution.Is {
   @Override
   protected Object internalEvaluate(Context context) {
     Object operand = getOperand().evaluate(context);
-    Class type = resolveType(context);
+    Class<?> type = resolveType(context);
 
     return is(type, operand);
   }

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/LastEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/LastEvaluator.java
@@ -18,7 +18,7 @@ public class LastEvaluator extends org.cqframework.cql.elm.execution.Last {
         }
 
         Object result = null;
-        for (Object element : (Iterable) source) {
+        for (Object element : (Iterable<?>) source) {
             result = element;
         }
 

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/LengthEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/LengthEvaluator.java
@@ -28,7 +28,7 @@ public class LengthEvaluator extends org.cqframework.cql.elm.execution.Length {
         }
 
         if (operand instanceof Iterable) {
-            return listLength((Iterable) operand);
+            return listLength((Iterable<?>) operand);
         }
 
         throw new InvalidOperatorArgument(
@@ -45,7 +45,7 @@ public class LengthEvaluator extends org.cqframework.cql.elm.execution.Length {
         return operand.length();
     }
 
-    public static Integer listLength(Iterable operand) {
+    public static Integer listLength(Iterable<?> operand) {
         if (operand == null) {
             return 0;
         }
@@ -63,7 +63,7 @@ public class LengthEvaluator extends org.cqframework.cql.elm.execution.Length {
                 return stringLength((String) operand);
             }
             else {
-                return listLength((Iterable) operand);
+                return listLength((Iterable<?>) operand);
             }
         }
 

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/MaxEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/MaxEvaluator.java
@@ -30,8 +30,8 @@ public class MaxEvaluator extends org.cqframework.cql.elm.execution.Max {
         }
 
         if (source instanceof Iterable) {
-            Iterable element = (Iterable)source;
-            Iterator itr = element.iterator();
+            Iterable<?> element = (Iterable<?>)source;
+            Iterator<?> itr = element.iterator();
 
             if (!itr.hasNext()) { // empty list
                 return null;

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/MedianEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/MedianEvaluator.java
@@ -26,8 +26,8 @@ public class MedianEvaluator extends org.cqframework.cql.elm.execution.Median {
         }
 
         if (source instanceof Iterable) {
-            Iterable element = (Iterable) source;
-            Iterator itr = element.iterator();
+            Iterable<?> element = (Iterable<?>) source;
+            Iterator<?> itr = element.iterator();
 
             if (!itr.hasNext()) { // empty
                 return null;

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/MinEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/MinEvaluator.java
@@ -30,8 +30,8 @@ public class MinEvaluator extends org.cqframework.cql.elm.execution.Min {
         }
 
         if (source instanceof Iterable) {
-            Iterable element = (Iterable)source;
-            Iterator itr = element.iterator();
+            Iterable<?> element = (Iterable<?>)source;
+            Iterator<?> itr = element.iterator();
 
             if (!itr.hasNext()) { // empty list
                 return null;

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/ModeEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/ModeEvaluator.java
@@ -23,8 +23,8 @@ public class ModeEvaluator extends org.cqframework.cql.elm.execution.Mode {
         }
 
         if (source instanceof Iterable) {
-            Iterable element = (Iterable)source;
-            Iterator itr = element.iterator();
+            Iterable<?> element = (Iterable<?>)source;
+            Iterator<?> itr = element.iterator();
 
             if (!itr.hasNext()) { // empty list
                 return null;

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/PopulationStdDevEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/PopulationStdDevEvaluator.java
@@ -27,7 +27,7 @@ public class PopulationStdDevEvaluator extends org.cqframework.cql.elm.execution
 
         if (source instanceof Iterable) {
 
-            if (((List) source).isEmpty()) {
+            if (((List<?>) source).isEmpty()) {
                 return null;
             }
 

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/PopulationVarianceEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/PopulationVarianceEvaluator.java
@@ -26,7 +26,7 @@ public class PopulationVarianceEvaluator extends org.cqframework.cql.elm.executi
 
         if (source instanceof Iterable) {
 
-            if (((List) source).isEmpty()) {
+            if (((List<?>) source).isEmpty()) {
                 return null;
             }
 
@@ -34,7 +34,7 @@ public class PopulationVarianceEvaluator extends org.cqframework.cql.elm.executi
 
             List<Object> newVals = new ArrayList<>();
 
-            ((List) source).forEach(ae -> newVals.add(
+            ((List<?>) source).forEach(ae -> newVals.add(
                     MultiplyEvaluator.multiply(
                             SubtractEvaluator.subtract(ae, mean),
                             SubtractEvaluator.subtract(ae, mean))

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/ProductEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/ProductEvaluator.java
@@ -29,7 +29,7 @@ public class ProductEvaluator extends org.cqframework.cql.elm.execution.Product 
 
         if (source instanceof Iterable) {
             Object result = null;
-            for (Object element : (Iterable) source) {
+            for (Object element : (Iterable<?>) source) {
                 if (element == null) return null;
                 if (result == null) {
                     result = element;

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/ProperContainsEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/ProperContainsEvaluator.java
@@ -32,7 +32,7 @@ public class ProperContainsEvaluator extends org.cqframework.cql.elm.execution.P
         }
 
         else if (left instanceof Iterable) {
-            List leftList = (List) left;
+            List<?> leftList = (List<?>) left;
 
             for (Object element : leftList) {
                 Boolean isElementInList = EquivalentEvaluator.equivalent(element, right);

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/ProperlyIncludedInEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/ProperlyIncludedInEvaluator.java
@@ -29,7 +29,7 @@ Note that the order of elements does not matter for the purposes of determining 
 
 public class ProperlyIncludedInEvaluator extends org.cqframework.cql.elm.execution.ProperIncludedIn {
 
-    public static Object properlyIncudedIn(Object left, Object right, String precision) {
+    public static Object properlyIncludedIn(Object left, Object right, String precision) {
         if (left == null && right == null) {
             return null;
         }
@@ -38,13 +38,13 @@ public class ProperlyIncludedInEvaluator extends org.cqframework.cql.elm.executi
             if (left == null) {
                 return right instanceof Interval
                         ? ProperlyIncludesEvaluator.intervalProperlyIncludes((Interval) right, null, precision)
-                        : ProperlyIncludesEvaluator.listProperlyIncludes((Iterable) right, null);
+                        : ProperlyIncludesEvaluator.listProperlyIncludes((Iterable<?>) right, null);
             }
 
             if (right == null) {
                 return left instanceof Interval
                         ? ProperlyIncludesEvaluator.intervalProperlyIncludes(null, (Interval) left, precision)
-                        : ProperlyIncludesEvaluator.listProperlyIncludes(null, (Iterable) left);
+                        : ProperlyIncludesEvaluator.listProperlyIncludes(null, (Iterable<?>) left);
             }
 
             return ProperlyIncludesEvaluator.properlyIncludes(right, left, precision);
@@ -63,6 +63,6 @@ public class ProperlyIncludedInEvaluator extends org.cqframework.cql.elm.executi
         Object right = getOperand().get(1).evaluate(context);
         String precision = getPrecision() != null ? getPrecision().value() : null;
 
-        return properlyIncudedIn(left, right, precision);
+        return properlyIncludedIn(left, right, precision);
     }
 }

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/ProperlyIncludesEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/ProperlyIncludesEvaluator.java
@@ -39,20 +39,20 @@ public class ProperlyIncludesEvaluator extends org.cqframework.cql.elm.execution
         if (left == null) {
             return right instanceof Interval
                     ? intervalProperlyIncludes(null, (Interval) right, precision)
-                    : listProperlyIncludes(null, (Iterable) right);
+                    : listProperlyIncludes(null, (Iterable<?>) right);
         }
 
         if (right == null) {
             return left instanceof Interval
                     ? intervalProperlyIncludes((Interval) left, null, precision)
-                    : listProperlyIncludes((Iterable) left, null);
+                    : listProperlyIncludes((Iterable<?>) left, null);
         }
 
         if (left instanceof Interval && right instanceof Interval) {
             return intervalProperlyIncludes((Interval) left, (Interval) right, precision);
         }
         if (left instanceof Iterable && right instanceof Iterable) {
-            return listProperlyIncludes((Iterable) left, (Iterable) right);
+            return listProperlyIncludes((Iterable<?>) left, (Iterable<?>) right);
         }
 
         throw new InvalidOperatorArgument(
@@ -88,7 +88,7 @@ public class ProperlyIncludesEvaluator extends org.cqframework.cql.elm.execution
         );
     }
 
-    public static Boolean listProperlyIncludes(Iterable left, Iterable right) {
+    public static Boolean listProperlyIncludes(Iterable<?> left, Iterable<?> right) {
         if (left == null) {
             return false;
         }

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/QueryEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/QueryEvaluator.java
@@ -17,6 +17,7 @@ import org.opencds.cqf.cql.runtime.iterators.QueryIterator;
 
 public class QueryEvaluator extends org.cqframework.cql.elm.execution.Query {
 
+    @SuppressWarnings("unchecked")
     public Iterable<Object> ensureIterable(Object source) {
         if (source instanceof Iterable) {
             return (Iterable<Object>) source;
@@ -149,10 +150,11 @@ public class QueryEvaluator extends org.cqframework.cql.elm.execution.Query {
         }
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     protected Object internalEvaluate(Context context) {
 
-        ArrayList<Iterator> sources = new ArrayList<Iterator>();
+        ArrayList<Iterator<Object>> sources = new ArrayList<Iterator<Object>>();
         ArrayList<Variable> variables = new ArrayList<Variable>();
         ArrayList<Variable> letVariables = new ArrayList<Variable>();
         List<Object> result = new ArrayList<>();

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/RetrieveEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/RetrieveEvaluator.java
@@ -13,6 +13,7 @@ import org.opencds.cqf.cql.runtime.Interval;
 
 public class RetrieveEvaluator extends org.cqframework.cql.elm.execution.Retrieve {
 
+    @SuppressWarnings("unchecked")
     protected Object internalEvaluate(Context context) {
         DataProvider dataProvider = context.resolveDataProvider(this.dataType);
         Iterable<Code> codes = null;
@@ -60,7 +61,7 @@ public class RetrieveEvaluator extends org.cqframework.cql.elm.execution.Retriev
 
         //append list results to evaluatedResources list
         if (result instanceof List) {
-            for (Object element : (List)result) {
+            for (Object element : (List<?>)result) {
                 context.getEvaluatedResources().add(element);
             }
         }

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/SingletonFromEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/SingletonFromEvaluator.java
@@ -23,7 +23,7 @@ public class SingletonFromEvaluator extends org.cqframework.cql.elm.execution.Si
         Object result = null;
         boolean first = true;
         if (operand instanceof Iterable) {
-            for (Object element : (Iterable) operand) {
+            for (Object element : (Iterable<?>) operand) {
                 if (first) {
                     result = element;
                     first = false;

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/SliceEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/SliceEvaluator.java
@@ -46,8 +46,8 @@ public class SliceEvaluator extends org.cqframework.cql.elm.execution.Slice {
         if (source instanceof Iterable) {
             List<Object> ret = new ArrayList<>();
 
-            if (end == null || end > ((List) source).size()) {
-                end = ((List) source).size();
+            if (end == null || end > ((List<?>) source).size()) {
+                end = ((List<?>) source).size();
             }
 
             if (end < 0) {
@@ -55,7 +55,7 @@ public class SliceEvaluator extends org.cqframework.cql.elm.execution.Slice {
             }
 
             for (; start < end; ++start) {
-                ret.add(((List) source).get(start));
+                ret.add(((List<?>) source).get(start));
             }
 
             return ret;

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/StdDevEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/StdDevEvaluator.java
@@ -27,7 +27,7 @@ public class StdDevEvaluator extends org.cqframework.cql.elm.execution.StdDev {
 
         if (source instanceof Iterable) {
 
-            if (((List) source).isEmpty()) {
+            if (((List<?>) source).isEmpty()) {
                 return null;
             }
 

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/SumEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/SumEvaluator.java
@@ -22,7 +22,7 @@ public class SumEvaluator extends org.cqframework.cql.elm.execution.Sum {
         }
 
         if (source instanceof Iterable) {
-            Iterable elements = (Iterable)source;
+            Iterable<?> elements = (Iterable<?>)source;
             Object sum = null;
             for (Object element : elements) {
                 if (element == null) {

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/ToConceptEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/ToConceptEvaluator.java
@@ -23,7 +23,7 @@ public class ToConceptEvaluator extends org.cqframework.cql.elm.execution.ToConc
         Concept result = new Concept();
 
         if (operand instanceof Iterable) {
-            for (Object code : (Iterable) operand) {
+            for (Object code : (Iterable<?>) operand) {
                 result.withCode((Code)code);
             }
             return result;

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/TruncateEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/TruncateEvaluator.java
@@ -1,6 +1,7 @@
 package org.opencds.cqf.cql.elm.execution;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 
 import org.opencds.cqf.cql.exception.InvalidOperatorArgument;
 import org.opencds.cqf.cql.execution.Context;
@@ -23,10 +24,10 @@ public class TruncateEvaluator extends org.cqframework.cql.elm.execution.Truncat
         if (operand instanceof BigDecimal) {
             Double val = ((BigDecimal) operand).doubleValue();
             if (val < 0){
-                return ((BigDecimal) operand).setScale(0, BigDecimal.ROUND_CEILING).intValue();
+                return ((BigDecimal) operand).setScale(0, RoundingMode.CEILING).intValue();
             }
             else {
-                return ((BigDecimal) operand).setScale(0, BigDecimal.ROUND_FLOOR).intValue();
+                return ((BigDecimal) operand).setScale(0, RoundingMode.FLOOR).intValue();
             }
         }
 

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/UnionEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/UnionEvaluator.java
@@ -69,11 +69,11 @@ public class UnionEvaluator extends org.cqframework.cql.elm.execution.Union {
         else if (left instanceof Iterable) {
             // List Logic
             List<Object> result = new ArrayList<>();
-            for (Object leftElement : (Iterable)left) {
+            for (Object leftElement : (Iterable<?>)left) {
                 result.add(leftElement);
             }
 
-            for (Object rightElement : (Iterable)right) {
+            for (Object rightElement : (Iterable<?>)right) {
                 result.add(rightElement);
             }
             return DistinctEvaluator.distinct(result);

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/VarianceEvaluator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/elm/execution/VarianceEvaluator.java
@@ -28,7 +28,7 @@ public class VarianceEvaluator extends org.cqframework.cql.elm.execution.Varianc
 
         if (source instanceof Iterable) {
 
-            if (((List) source).isEmpty()) {
+            if (((List<?>) source).isEmpty()) {
                 return null;
             }
 
@@ -36,7 +36,7 @@ public class VarianceEvaluator extends org.cqframework.cql.elm.execution.Varianc
 
             List<Object> newVals = new ArrayList<>();
 
-            for (Object element : (Iterable) source) {
+            for (Object element : (Iterable<?>) source) {
                 if (element != null) {
                     if (element instanceof BigDecimal || element instanceof Quantity) {
                         newVals.add(MultiplyEvaluator.multiply(

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/exception/CqlException.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/exception/CqlException.java
@@ -2,6 +2,8 @@ package org.opencds.cqf.cql.exception;
 
 public class CqlException extends RuntimeException
 {
+    private static final long serialVersionUID = 1L;
+
     public CqlException(String message)
     {
         super(message);

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/exception/InvalidCast.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/exception/InvalidCast.java
@@ -2,6 +2,8 @@ package org.opencds.cqf.cql.exception;
 
 public class InvalidCast extends CqlException
 {
+    private static final long serialVersionUID = 1L;
+
     public InvalidCast(String message) {
         super(message);
     }

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/exception/InvalidComparison.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/exception/InvalidComparison.java
@@ -1,6 +1,8 @@
 package org.opencds.cqf.cql.exception;
 
 public class InvalidComparison extends CqlException {
+    private static final long serialVersionUID = 1L;
+
     public InvalidComparison(String message) {
         super(message);
     }

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/exception/InvalidConversion.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/exception/InvalidConversion.java
@@ -1,6 +1,8 @@
 package org.opencds.cqf.cql.exception;
 
 public class InvalidConversion extends CqlException {
+    private static final long serialVersionUID = 1L;
+
     public InvalidConversion(String message) {
         super(message);
     }

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/exception/InvalidDate.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/exception/InvalidDate.java
@@ -1,6 +1,8 @@
 package org.opencds.cqf.cql.exception;
 
 public class InvalidDate extends CqlException {
+    private static final long serialVersionUID = 1L;
+
     public InvalidDate(String message) {
         super(message);
     }

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/exception/InvalidDateTime.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/exception/InvalidDateTime.java
@@ -1,6 +1,8 @@
 package org.opencds.cqf.cql.exception;
 
 public class InvalidDateTime extends CqlException {
+    private static final long serialVersionUID = 1L;
+
     public InvalidDateTime(String message) {
         super(message);
     }

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/exception/InvalidInterval.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/exception/InvalidInterval.java
@@ -1,6 +1,8 @@
 package org.opencds.cqf.cql.exception;
 
 public class InvalidInterval extends CqlException {
+    private static final long serialVersionUID = 1L;
+
     public InvalidInterval(String message) {
         super(message);
     }

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/exception/InvalidLiteral.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/exception/InvalidLiteral.java
@@ -1,6 +1,8 @@
 package org.opencds.cqf.cql.exception;
 
 public class InvalidLiteral extends CqlException {
+    private static final long serialVersionUID = 1L;
+
     public InvalidLiteral(String message) {
         super(message);
     }

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/exception/InvalidOperatorArgument.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/exception/InvalidOperatorArgument.java
@@ -2,6 +2,8 @@ package org.opencds.cqf.cql.exception;
 
 public class InvalidOperatorArgument extends CqlException
 {
+    private static final long serialVersionUID = 1L;
+
     public InvalidOperatorArgument(String message)
     {
         super(message);

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/exception/InvalidPrecision.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/exception/InvalidPrecision.java
@@ -1,6 +1,8 @@
 package org.opencds.cqf.cql.exception;
 
 public class InvalidPrecision extends CqlException {
+    private static final long serialVersionUID = 1L;
+
     public InvalidPrecision(String message) {
         super(message);
     }

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/exception/InvalidTime.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/exception/InvalidTime.java
@@ -1,6 +1,8 @@
 package org.opencds.cqf.cql.exception;
 
 public class InvalidTime extends CqlException {
+    private static final long serialVersionUID = 1L;
+
     public InvalidTime(String message) {
         super(message);
     }

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/exception/TypeOverflow.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/exception/TypeOverflow.java
@@ -1,6 +1,8 @@
 package org.opencds.cqf.cql.exception;
 
 public class TypeOverflow extends CqlException {
+    private static final long serialVersionUID = 1L;
+
     public TypeOverflow(String message) {
         super(message);
     }

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/exception/TypeUnderflow.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/exception/TypeUnderflow.java
@@ -1,6 +1,8 @@
 package org.opencds.cqf.cql.exception;
 
 public class TypeUnderflow extends CqlException {
+    private static final long serialVersionUID = 1L;
+
     public TypeUnderflow(String message) {
         super(message);
     }

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/exception/UndefinedResult.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/exception/UndefinedResult.java
@@ -1,6 +1,8 @@
 package org.opencds.cqf.cql.exception;
 
 public class UndefinedResult extends CqlException {
+    private static final long serialVersionUID = 1L;
+
     public UndefinedResult(String message) {
         super(message);
     }

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/execution/Context.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/execution/Context.java
@@ -38,6 +38,7 @@ import org.opencds.cqf.cql.terminology.TerminologyProvider;
  * NOTE: This class is thread-affine; it uses thread local storage to allow statics throughout the code base to access
  * the context (such as equal and equivalent evaluators).
  */
+
 public class Context {
 
     private static ThreadLocal<Context> threadContext = new ThreadLocal<>();
@@ -46,6 +47,8 @@ public class Context {
     }
 
     private boolean enableExpressionCache = false;
+
+    @SuppressWarnings("serial")
     private LinkedHashMap<String, Object> expressions = new LinkedHashMap<String, Object>(15, 0.9f, true) {
         protected boolean removeEldestEntry(Map.Entry<String, Object> eldest) {
             return size() > 10;
@@ -219,12 +222,12 @@ public class Context {
         return dataProvider.createInstance(typeName.getLocalPart());
     }
 
-    public Class resolveType(QName typeName) {
+    public Class<?> resolveType(QName typeName) {
         DataProvider dataProvider = resolveDataProvider(typeName);
         return dataProvider.resolveType(typeName.getLocalPart());
     }
 
-    public Class resolveType(TypeSpecifier typeSpecifier) {
+    public Class<?> resolveType(TypeSpecifier typeSpecifier) {
         if (typeSpecifier instanceof NamedTypeSpecifier) {
             return resolveType(((NamedTypeSpecifier)typeSpecifier).getName());
         }
@@ -246,7 +249,7 @@ public class Context {
         }
     }
 
-    public Class resolveType(Object value) {
+    public Class<?> resolveType(Object value) {
         if (value == null) {
             return null;
         }
@@ -272,7 +275,7 @@ public class Context {
         return dataProvider.resolveType(value);
     }
 
-    private Class resolveOperandType(OperandDef operandDef) {
+    private Class<?> resolveOperandType(OperandDef operandDef) {
         if (operandDef.getOperandTypeSpecifier() != null) {
             return resolveType(operandDef.getOperandTypeSpecifier());
         }
@@ -281,7 +284,7 @@ public class Context {
         }
     }
 
-    private boolean isType(Class argumentType, Class operandType) {
+    private boolean isType(Class<?> argumentType, Class<?> operandType) {
         return argumentType == null || operandType.isAssignableFrom(argumentType);
     }
 

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/execution/CqlEngine.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/execution/CqlEngine.java
@@ -209,24 +209,24 @@ public class CqlEngine {
         return library;
     }
 
-    private void validateDataRequirements(Library library) {
-        if (library.getUsings() != null && library.getUsings().getDef() != null && !library.getUsings().getDef().isEmpty())
-        {
-            for (UsingDef using : library.getUsings().getDef()) {
-                // Skip system using since the context automatically registers that.
-                if (using.getUri().equals("urn:hl7-org:elm-types:r1"))
-                {
-                    continue;
-                }
+    // private void validateDataRequirements(Library library) {
+    //     if (library.getUsings() != null && library.getUsings().getDef() != null && !library.getUsings().getDef().isEmpty())
+    //     {
+    //         for (UsingDef using : library.getUsings().getDef()) {
+    //             // Skip system using since the context automatically registers that.
+    //             if (using.getUri().equals("urn:hl7-org:elm-types:r1"))
+    //             {
+    //                 continue;
+    //             }
 
-                if (this.dataProviders == null || !this.dataProviders.containsKey(using.getUri())) {
-                    throw new IllegalArgumentException(String.format("Library %1$s is using %2$s and no data provider is registered for uri %2$s.",
-                    this.getLibraryDescription(library.getIdentifier()),
-                    using.getUri()));
-                }
-            }
-        }
-    }
+    //             if (this.dataProviders == null || !this.dataProviders.containsKey(using.getUri())) {
+    //                 throw new IllegalArgumentException(String.format("Library %1$s is using %2$s and no data provider is registered for uri %2$s.",
+    //                 this.getLibraryDescription(library.getIdentifier()),
+    //                 using.getUri()));
+    //             }
+    //         }
+    //     }
+    // }
 
     private void validateTerminologyRequirements(Library library) {
         if ((library.getCodeSystems() != null && library.getCodeSystems().getDef() != null && !library.getCodeSystems().getDef().isEmpty()) || 

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/execution/CqlLibraryReader.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/execution/CqlLibraryReader.java
@@ -76,6 +76,7 @@ public class CqlLibraryReader {
         return read(u, toSource(reader));
     }
 
+    @SuppressWarnings("unchecked")
     public static Library read(Unmarshaller u, Source source) throws JAXBException {
         Object result = u.unmarshal(source);
         return ((JAXBElement<Library>)result).getValue();
@@ -106,6 +107,7 @@ public class CqlLibraryReader {
         return read(toSource(reader));
     }
 
+    @SuppressWarnings("unchecked")
     public static Library read(Source source) throws JAXBException {
         Unmarshaller u = getUnmarshaller();
         Object result = u.unmarshal(source);

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/runtime/CqlList.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/runtime/CqlList.java
@@ -65,6 +65,7 @@ public class CqlList {
         }
     };
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     public int compareTo(Object left, Object right) {
         if (left == null && right == null) return 0;
         else if (left == null) return -1;
@@ -77,9 +78,9 @@ public class CqlList {
         }
     }
 
-    public static Boolean equivalent(Iterable left, Iterable right) {
-        Iterator leftIterator = left.iterator();
-        Iterator rightIterator = right.iterator();
+    public static Boolean equivalent(Iterable<?> left, Iterable<?> right) {
+        Iterator<?> leftIterator = left.iterator();
+        Iterator<?> rightIterator = right.iterator();
 
         while (leftIterator.hasNext()) {
             Object leftObject = leftIterator.next();
@@ -96,16 +97,16 @@ public class CqlList {
         return !rightIterator.hasNext();
     }
 
-    public static Boolean equal(Iterable left, Iterable right) {
-        Iterator leftIterator = left.iterator();
-        Iterator rightIterator = right.iterator();
+    public static Boolean equal(Iterable<?> left, Iterable<?> right) {
+        Iterator<?> leftIterator = left.iterator();
+        Iterator<?> rightIterator = right.iterator();
 
         while (leftIterator.hasNext()) {
             Object leftObject = leftIterator.next();
             if (rightIterator.hasNext()) {
                 Object rightObject = rightIterator.next();
                 if (leftObject instanceof Iterable && rightObject instanceof Iterable) {
-                    return equal((Iterable) leftObject, (Iterable) rightObject);
+                    return equal((Iterable<?>) leftObject, (Iterable<?>) rightObject);
                 }
                 Boolean elementEquals = EqualEvaluator.equal(leftObject, rightObject);
                 if (elementEquals == null || !elementEquals) {

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/runtime/TemporalHelper.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/runtime/TemporalHelper.java
@@ -13,7 +13,6 @@ public class TemporalHelper {
 
     public static String[] normalizeDateTimeElements(int ... elements) {
         String[] ret = new String[elements.length];
-        String strElement = "";
         for (int i = 0; i < elements.length; ++i) {
             switch (i) {
                 case 0: ret[i] = addLeadingZeroes(elements[i], 4); break;
@@ -27,7 +26,6 @@ public class TemporalHelper {
 
     public static String[] normalizeTimeElements(int ... elements) {
         String[] ret = new String[elements.length];
-        String strElement = "";
         for (int i = 0; i < elements.length; ++i) {
             switch (i) {
                 case 3: ret[i] = addLeadingZeroes(elements[i], 3); break;

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/runtime/Time.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/runtime/Time.java
@@ -141,7 +141,6 @@ public class Time extends BaseTemporal {
     public Integer compare(BaseTemporal other, boolean forSort) {
         boolean differentPrecisions = this.getPrecision() != other.getPrecision();
 
-        Precision thePrecision;
         if (differentPrecisions) {
             Integer result = this.compareToPrecision(other, Precision.getHighestTimePrecision(this.precision, other.precision));
             if (result == null && forSort) {

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/runtime/iterators/QueryIterator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/runtime/iterators/QueryIterator.java
@@ -10,17 +10,14 @@ import org.opencds.cqf.cql.execution.Context;
 /**
  * Created by Bryn on 8/11/2019.
  */
+
 public class QueryIterator implements Iterator<Object> {
 
-    private Context context;
-    private List<Iterator> sources;
     private Iterator<Object> sourceIterator;
     private ArrayList<Object> result;
 
-    public QueryIterator(Context context, List<Iterator> sources) {
-        this.context = context;
-        this.sources = sources;
-        this.result = new ArrayList(sources.size());
+    public QueryIterator(Context context, List<Iterator<Object>> sources) {
+        this.result = new ArrayList<>(sources.size());
 
         for (int i = sources.size() - 1; i >= 0; i--) {
             if (sourceIterator == null) {
@@ -50,8 +47,8 @@ public class QueryIterator implements Iterator<Object> {
 
     private void unpair(Object element, List<Object> target, int index) {
         if (element instanceof Map.Entry) {
-            unpair(((Map.Entry)element).getKey(), target, index);
-            unpair(((Map.Entry)element).getValue(), target, index + 1);
+            unpair(((Map.Entry<?,?>)element).getKey(), target, index);
+            unpair(((Map.Entry<?,?>)element).getValue(), target, index + 1);
         }
         else {
             target.set(index, element);

--- a/cql-engine/src/main/java/org/opencds/cqf/cql/runtime/iterators/TimesIterator.java
+++ b/cql-engine/src/main/java/org/opencds/cqf/cql/runtime/iterators/TimesIterator.java
@@ -1,9 +1,9 @@
 package org.opencds.cqf.cql.runtime.iterators;
 
 import java.util.AbstractMap;
-import java.util.ArrayList;
+
 import java.util.Iterator;
-import java.util.List;
+
 
 /**
  * Created by Bryn on 8/11/2019.
@@ -12,7 +12,6 @@ public class TimesIterator implements Iterator<Object> {
 
     private Iterator<Object> left;
     private ResetIterator<Object> right;
-    private List<Object> rightData = new ArrayList<Object>();
     private boolean leftNeeded = true;
     private Object leftElement;
 

--- a/cql-engine/src/test/java/org/opencds/cqf/cql/execution/CqlAggregateFunctionsTest.java
+++ b/cql-engine/src/test/java/org/opencds/cqf/cql/execution/CqlAggregateFunctionsTest.java
@@ -109,7 +109,6 @@ public class CqlAggregateFunctionsTest extends CqlExecutionTestBase {
         }
         catch (InvalidOperatorArgument e) {
             // pass
-            String s = "s";
         }
     }
 

--- a/cql-engine/src/test/java/org/opencds/cqf/cql/execution/CqlDateTimeOperatorsTest.java
+++ b/cql-engine/src/test/java/org/opencds/cqf/cql/execution/CqlDateTimeOperatorsTest.java
@@ -1003,8 +1003,8 @@ public class CqlDateTimeOperatorsTest extends CqlExecutionTestBase {
      */
     @Test
     public void testTimeOfDay() throws JAXBException {
-        Context context = new Context(library);
         // TODO: uncomment once Time(x,x,x,x,x) format is fixed
+        //Context context = new Context(library);
         // Object result = context.resolveExpressionRef("TimeOfDayTest").getExpression().evaluate(context);
         // assertThat(((Time)result).getPartial().getValue(0), is(10));
     }

--- a/cql-engine/src/test/java/org/opencds/cqf/cql/execution/CqlEngineTests.java
+++ b/cql-engine/src/test/java/org/opencds/cqf/cql/execution/CqlEngineTests.java
@@ -11,13 +11,13 @@ import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.Map.Entry;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
@@ -66,7 +66,7 @@ public class CqlEngineTests {
         return expressionMap;
     }
 
-    private Map<VersionedIdentifier, Set<String>> mergeExpressionMaps(Map<VersionedIdentifier, Set<String>>... maps) {
+    private Map<VersionedIdentifier, Set<String>> mergeExpressionMaps(Collection<Map<VersionedIdentifier, Set<String>>> maps) {
         Map<VersionedIdentifier, Set<String>> mergedMaps = new HashMap<VersionedIdentifier, Set<String>>();
         for (Map<VersionedIdentifier, Set<String>> map : maps) {
            mergedMaps.putAll(map);
@@ -81,23 +81,6 @@ public class CqlEngineTests {
 
     private VersionedIdentifier toExecutionIdentifier(String name, String version) {
         return new VersionedIdentifier().withId(name).withVersion(version);
-    }
-
-    private Map<String, String> getLibrariesAsXML(LibraryManager libraryManager) {
-        Map<String, String> result = new HashMap<String, String>();
-        for (Map.Entry<String, TranslatedLibrary> entry : libraryManager.getTranslatedLibraries().entrySet()) {
-            result.put(entry.getKey(), toXml(entry.getValue().getLibrary()));
-        }
-        return result;
-    }
-
-    private String toXml(org.hl7.elm.r1.Library library) {
-        try {
-            return convertToXml(library);
-        }
-        catch (JAXBException e) {
-            throw new IllegalArgumentException("Could not convert library to XML.", e);
-        }
     }
 
     public String convertToXml(org.hl7.elm.r1.Library library) throws JAXBException {
@@ -116,7 +99,7 @@ public class CqlEngineTests {
     
     @Test(expected = IllegalArgumentException.class)
     public void test_nullLibraryLoader_throwsException() {
-        CqlEngine engine = new CqlEngine(null);
+        new CqlEngine(null);
     }
 
     @Test
@@ -217,9 +200,9 @@ public class CqlEngineTests {
             executableLibraries.add(this.readXml(xml));
         }
 
-        Map<VersionedIdentifier, Set<String>> expressions = this.mergeExpressionMaps(
+        Map<VersionedIdentifier, Set<String>> expressions = this.mergeExpressionMaps(List.of(
             this.toExpressionMap(toExecutionIdentifier("Common", "1.0.0"), "Z"),
-            this.toExpressionMap(toExecutionIdentifier("Test", "1.0.0"), "X", "Y", "W")
+            this.toExpressionMap(toExecutionIdentifier("Test", "1.0.0"), "X", "Y", "W"))
         );
 
         LibraryLoader libraryLoader = new InMemoryLibraryLoader(executableLibraries);

--- a/cql-engine/src/test/java/org/opencds/cqf/cql/execution/CqlIntervalOperatorsTest.java
+++ b/cql-engine/src/test/java/org/opencds/cqf/cql/execution/CqlIntervalOperatorsTest.java
@@ -182,54 +182,54 @@ public class CqlIntervalOperatorsTest extends CqlExecutionTestBase {
         assertThat(result, is(nullValue()));
 
         result = context.resolveExpressionRef("IntegerIntervalCollapse").getExpression().evaluate(context);
-        Assert.assertTrue(((Interval)((List) result).get(0)).equal(new Interval(1, true, 10, true)));
-        Assert.assertTrue(((Interval)((List) result).get(1)).equal(new Interval(12, true, 19, true)));
+        Assert.assertTrue(((Interval)((List<?>) result).get(0)).equal(new Interval(1, true, 10, true)));
+        Assert.assertTrue(((Interval)((List<?>) result).get(1)).equal(new Interval(12, true, 19, true)));
 
         result = context.resolveExpressionRef("IntegerIntervalCollapse2").getExpression().evaluate(context);
-        Assert.assertTrue(((Interval)((List) result).get(0)).equal(new Interval(1, true, 19, true)));
+        Assert.assertTrue(((Interval)((List<?>) result).get(0)).equal(new Interval(1, true, 19, true)));
 
         result = context.resolveExpressionRef("IntegerIntervalCollapse3").getExpression().evaluate(context);
-        Assert.assertTrue(((Interval)((List) result).get(0)).equal(new Interval(4, true, 8, true)));
+        Assert.assertTrue(((Interval)((List<?>) result).get(0)).equal(new Interval(4, true, 8, true)));
 
         result = context.resolveExpressionRef("IntegerIntervalCollapse4").getExpression().evaluate(context);
-        Assert.assertTrue(((Interval)((List) result).get(0)).equal(new Interval(4, true, 6, true)));
-        Assert.assertTrue(((Interval)((List) result).get(1)).equal(new Interval(8, true, 10, true)));
+        Assert.assertTrue(((Interval)((List<?>) result).get(0)).equal(new Interval(4, true, 6, true)));
+        Assert.assertTrue(((Interval)((List<?>) result).get(1)).equal(new Interval(8, true, 10, true)));
 
         result = context.resolveExpressionRef("DecimalIntervalCollapse").getExpression().evaluate(context);
-        Assert.assertTrue(((Interval)((List) result).get(0)).equal(new Interval(new BigDecimal("1.0"), true, new BigDecimal("10.0"), true)));
-        Assert.assertTrue(((Interval)((List) result).get(1)).equal(new Interval(new BigDecimal("12.0"), true, new BigDecimal("19.0"), true)));
+        Assert.assertTrue(((Interval)((List<?>) result).get(0)).equal(new Interval(new BigDecimal("1.0"), true, new BigDecimal("10.0"), true)));
+        Assert.assertTrue(((Interval)((List<?>) result).get(1)).equal(new Interval(new BigDecimal("12.0"), true, new BigDecimal("19.0"), true)));
 
         result = context.resolveExpressionRef("DecimalIntervalCollapse2").getExpression().evaluate(context);
-        Assert.assertTrue(((Interval)((List) result).get(0)).equal(new Interval(new BigDecimal("4.0"), true, new BigDecimal("8.0"), true)));
+        Assert.assertTrue(((Interval)((List<?>) result).get(0)).equal(new Interval(new BigDecimal("4.0"), true, new BigDecimal("8.0"), true)));
 
         result = context.resolveExpressionRef("QuantityIntervalCollapse").getExpression().evaluate(context);
-        Assert.assertTrue(((Interval)((List) result).get(0)).equal(new Interval(new Quantity().withValue(new BigDecimal("1.0")).withUnit("g"), true, new Quantity().withValue(new BigDecimal("10.0")).withUnit("g"), true)));
-        Assert.assertTrue(((Interval)((List) result).get(1)).equal(new Interval(new Quantity().withValue(new BigDecimal("12.0")).withUnit("g"), true, new Quantity().withValue(new BigDecimal("19.0")).withUnit("g"), true)));
+        Assert.assertTrue(((Interval)((List<?>) result).get(0)).equal(new Interval(new Quantity().withValue(new BigDecimal("1.0")).withUnit("g"), true, new Quantity().withValue(new BigDecimal("10.0")).withUnit("g"), true)));
+        Assert.assertTrue(((Interval)((List<?>) result).get(1)).equal(new Interval(new Quantity().withValue(new BigDecimal("12.0")).withUnit("g"), true, new Quantity().withValue(new BigDecimal("19.0")).withUnit("g"), true)));
 
         BigDecimal offset = TemporalHelper.getDefaultOffset();
         result = context.resolveExpressionRef("DateTimeCollapse").getExpression().evaluate(context);
-        Assert.assertTrue(EquivalentEvaluator.equivalent(((Interval)((List)result).get(0)).getStart(), new DateTime(offset, 2012, 1, 1)));
-        Assert.assertTrue(EquivalentEvaluator.equivalent(((Interval)((List)result).get(0)).getEnd(), new DateTime(offset, 2012, 1, 25)));
-        Assert.assertTrue(EquivalentEvaluator.equivalent(((Interval)((List)result).get(1)).getStart(), new DateTime(offset, 2012, 5, 10)));
-        Assert.assertTrue(EquivalentEvaluator.equivalent(((Interval)((List)result).get(1)).getEnd(), new DateTime(offset, 2012, 5, 30)));
-        assertThat(((List)result).size(), is(2));
+        Assert.assertTrue(EquivalentEvaluator.equivalent(((Interval)((List<?>)result).get(0)).getStart(), new DateTime(offset, 2012, 1, 1)));
+        Assert.assertTrue(EquivalentEvaluator.equivalent(((Interval)((List<?>)result).get(0)).getEnd(), new DateTime(offset, 2012, 1, 25)));
+        Assert.assertTrue(EquivalentEvaluator.equivalent(((Interval)((List<?>)result).get(1)).getStart(), new DateTime(offset, 2012, 5, 10)));
+        Assert.assertTrue(EquivalentEvaluator.equivalent(((Interval)((List<?>)result).get(1)).getEnd(), new DateTime(offset, 2012, 5, 30)));
+        assertThat(((List<?>)result).size(), is(2));
 
 //        result = context.resolveExpressionRef("DateTimeCollapse2").getExpression().evaluate(context);
-//        Assert.assertTrue(EquivalentEvaluator.equivalent(((Interval)((List)result).get(0)).getStart(), new DateTime(offset, 2012, 1, 1)));
-//        Assert.assertTrue(EquivalentEvaluator.equivalent(((Interval)((List)result).get(0)).getEnd(), new DateTime(offset, 2012, 5, 25)));
-//        assertThat(((List)result).size(), is(1));
+//        Assert.assertTrue(EquivalentEvaluator.equivalent(((Interval)((List<?>)result).get(0)).getStart(), new DateTime(offset, 2012, 1, 1)));
+//        Assert.assertTrue(EquivalentEvaluator.equivalent(((Interval)((List<?>)result).get(0)).getEnd(), new DateTime(offset, 2012, 5, 25)));
+//        assertThat(((List<?>)result).size(), is(1));
 
         result = context.resolveExpressionRef("TimeCollapse").getExpression().evaluate(context);
-        Assert.assertTrue(EquivalentEvaluator.equivalent(((Interval)((List)result).get(0)).getStart(), new Time(offset, 1, 59, 59, 999)));
-        Assert.assertTrue(EquivalentEvaluator.equivalent(((Interval)((List)result).get(0)).getEnd(), new Time(offset, 15, 59, 59, 999)));
-        Assert.assertTrue(EquivalentEvaluator.equivalent(((Interval)((List)result).get(1)).getStart(), new Time(offset, 17, 59, 59, 999)));
-        Assert.assertTrue(EquivalentEvaluator.equivalent(((Interval)((List)result).get(1)).getEnd(), new Time(offset, 22, 59, 59, 999)));
-        assertThat(((List)result).size(), is(2));
+        Assert.assertTrue(EquivalentEvaluator.equivalent(((Interval)((List<?>)result).get(0)).getStart(), new Time(offset, 1, 59, 59, 999)));
+        Assert.assertTrue(EquivalentEvaluator.equivalent(((Interval)((List<?>)result).get(0)).getEnd(), new Time(offset, 15, 59, 59, 999)));
+        Assert.assertTrue(EquivalentEvaluator.equivalent(((Interval)((List<?>)result).get(1)).getStart(), new Time(offset, 17, 59, 59, 999)));
+        Assert.assertTrue(EquivalentEvaluator.equivalent(((Interval)((List<?>)result).get(1)).getEnd(), new Time(offset, 22, 59, 59, 999)));
+        assertThat(((List<?>)result).size(), is(2));
 
         result = context.resolveExpressionRef("TimeCollapse2").getExpression().evaluate(context);
-        Assert.assertTrue(EquivalentEvaluator.equivalent(((Interval)((List)result).get(0)).getStart(), new Time(offset, 1, 59, 59, 999)));
-        Assert.assertTrue(EquivalentEvaluator.equivalent(((Interval)((List)result).get(0)).getEnd(), new Time(offset, 15, 59, 59, 999)));
-        assertThat(((List)result).size(), is(1));
+        Assert.assertTrue(EquivalentEvaluator.equivalent(((Interval)((List<?>)result).get(0)).getStart(), new Time(offset, 1, 59, 59, 999)));
+        Assert.assertTrue(EquivalentEvaluator.equivalent(((Interval)((List<?>)result).get(0)).getEnd(), new Time(offset, 15, 59, 59, 999)));
+        assertThat(((List<?>)result).size(), is(1));
     }
 
     /**

--- a/cql-engine/src/test/java/org/opencds/cqf/cql/execution/CqlListOperatorsTest.java
+++ b/cql-engine/src/test/java/org/opencds/cqf/cql/execution/CqlListOperatorsTest.java
@@ -22,6 +22,7 @@ import org.opencds.cqf.cql.runtime.Time;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+@SuppressWarnings("rawtypes")
 public class CqlListOperatorsTest extends CqlExecutionTestBase {
 
     @Test
@@ -74,7 +75,7 @@ public class CqlListOperatorsTest extends CqlExecutionTestBase {
         //    assertThat(result, is(Arrays.asList(new Quantity().withValue(new BigDecimal("19.99")).withUnit("lbs") , new Quantity().withValue(new BigDecimal("17.33")).withUnit("lbs") ,  new Quantity().withValue(new BigDecimal("10.66")).withUnit("lbs") )));
 
         result = context.resolveExpressionRef("dateTimeList").getExpression().evaluate(context);
-        List<DateTime> arrListDateTime = new ArrayList();
+        List<DateTime> arrListDateTime = new ArrayList<>();
         arrListDateTime.add(new DateTime(offset, 2016));
         arrListDateTime.add(new DateTime(offset, 2015));
         arrListDateTime.add(new DateTime(offset, 2010));
@@ -82,7 +83,7 @@ public class CqlListOperatorsTest extends CqlExecutionTestBase {
 
 
         result = context.resolveExpressionRef("timeList").getExpression().evaluate(context);
-        List<Time> arrList = new ArrayList();
+        List<Time> arrList = new ArrayList<>();
         arrList.add(new Time(offset, 15, 59, 59, 999));
         arrList.add(new Time(offset, 15, 12, 59, 999));
         arrList.add(new Time(offset, 15, 12, 13, 999));
@@ -135,7 +136,8 @@ public class CqlListOperatorsTest extends CqlExecutionTestBase {
     /**
      * {@link org.opencds.cqf.cql.elm.execution.DistinctEvaluator#evaluate(Context)}
      */
-    @Test
+    @Test    
+    @SuppressWarnings("serial")
     public void testDistinct() throws JAXBException {
         Context context = new Context(library);
 

--- a/cql-engine/src/test/java/org/opencds/cqf/cql/execution/CqlLogicalOperatorsTest.java
+++ b/cql-engine/src/test/java/org/opencds/cqf/cql/execution/CqlLogicalOperatorsTest.java
@@ -61,7 +61,7 @@ public class CqlLogicalOperatorsTest extends CqlExecutionTestBase {
      */
     @Test
     public void testImplies() throws JAXBException {
-        Context context = new Context(library);
+        //Context context = new Context(library);
         // TODO: uncomment this and cql once working
         // Object result = context.resolveExpressionRef("TrueImpliesTrue").getExpression().evaluate(context);
         // assertThat(result, is(true));

--- a/cql-engine/src/test/java/org/opencds/cqf/cql/execution/CqlQueryTests.java
+++ b/cql-engine/src/test/java/org/opencds/cqf/cql/execution/CqlQueryTests.java
@@ -24,7 +24,7 @@ public class CqlQueryTests extends CqlExecutionTestBase
 
         result = context.resolveExpressionRef("Multisource").getExpression().evaluate(context);
         Assert.assertTrue(result instanceof List);
-        List results = (List) result;
+        List<?> results = (List<?>) result;
         Assert.assertTrue(results.size() == 1);
         Assert.assertTrue(results.get(0) instanceof Tuple);
         Tuple resultTuple = (Tuple) results.get(0);
@@ -32,7 +32,7 @@ public class CqlQueryTests extends CqlExecutionTestBase
 
         result = context.resolveExpressionRef("Complex Multisource").getExpression().evaluate(context);
         Assert.assertTrue(result instanceof List);
-        results = (List) result;
+        results = (List<?>) result;
         Assert.assertTrue(results.size() == 4);
 
         result = context.resolveExpressionRef("Let Test Fails").getExpression().evaluate(context);
@@ -40,19 +40,19 @@ public class CqlQueryTests extends CqlExecutionTestBase
 
         result = context.resolveExpressionRef("Triple Source Query").getExpression().evaluate(context);
         Assert.assertTrue(result instanceof List);
-        results = (List) result;
+        results = (List<?>) result;
         Assert.assertTrue(results.size() == 27);
 
         result = context.resolveExpressionRef("Let Expression in Multi Source Query").getExpression().evaluate(context);
         Assert.assertTrue(result instanceof List);
-        results = (List) result;
+        results = (List<?>) result;
         Assert.assertTrue(results.size() == 1);
         Assert.assertTrue(EquivalentEvaluator.equivalent(results.get(0), 3));
 
 
         result = context.resolveExpressionRef("Accessing Third Element of Triple Source Query").getExpression().evaluate(context);
         Assert.assertTrue(result instanceof List);
-        results = (List) result;
+        results = (List<?>) result;
         Assert.assertTrue(results.size() == 1);
         Assert.assertTrue(EquivalentEvaluator.equivalent(results.get(0), 3));
     }

--- a/cql-engine/src/test/java/org/opencds/cqf/cql/execution/CqlTestSuite.java
+++ b/cql-engine/src/test/java/org/opencds/cqf/cql/execution/CqlTestSuite.java
@@ -261,28 +261,28 @@ public class CqlTestSuite {
 
         result = context.resolveExpressionRef("List_BoolList").evaluate(context);
         Assert.assertTrue(result instanceof Iterable);
-        Boolean listComp = CqlList.equal((Iterable) result, Arrays.asList(true, false, true));
+        Boolean listComp = CqlList.equal((Iterable<?>) result, Arrays.asList(true, false, true));
         Assert.assertTrue(listComp != null && listComp);
 
         result = context.resolveExpressionRef("List_IntList").evaluate(context);
         Assert.assertTrue(result instanceof Iterable);
-        listComp = CqlList.equal((Iterable) result, Arrays.asList(9, 7, 8));
+        listComp = CqlList.equal((Iterable<?>) result, Arrays.asList(9, 7, 8));
         Assert.assertTrue(listComp != null && listComp);
 
         result = context.resolveExpressionRef("List_DecimalList").evaluate(context);
         Assert.assertTrue(result instanceof Iterable);
-        listComp = CqlList.equal((Iterable) result, Arrays.asList(new BigDecimal("1.0"), new BigDecimal("2.1"), new BigDecimal("3.2")));
+        listComp = CqlList.equal((Iterable<?>) result, Arrays.asList(new BigDecimal("1.0"), new BigDecimal("2.1"), new BigDecimal("3.2")));
         Assert.assertTrue(listComp != null && listComp);
 
         result = context.resolveExpressionRef("List_StringList").evaluate(context);
         Assert.assertTrue(result instanceof Iterable);
-        listComp = CqlList.equal((Iterable) result, Arrays.asList("a", "bee", "see"));
+        listComp = CqlList.equal((Iterable<?>) result, Arrays.asList("a", "bee", "see"));
         Assert.assertTrue(listComp != null && listComp);
 
         result = context.resolveExpressionRef("List_DateTimeList").evaluate(context);
         Assert.assertTrue(result instanceof Iterable);
         listComp = CqlList.equal(
-                (Iterable) result,
+                (Iterable<?>) result,
                 Arrays.asList(
                         new DateTime(new BigDecimal("0.0"), 2012, 2, 15, 12, 10, 59, 456),
                         new DateTime(new BigDecimal("0.0"), 2012, 3, 15, 12, 10, 59, 456),
@@ -294,7 +294,7 @@ public class CqlTestSuite {
         result = context.resolveExpressionRef("List_TimeList").evaluate(context);
         Assert.assertTrue(result instanceof Iterable);
         listComp = CqlList.equal(
-                (Iterable) result,
+                (Iterable<?>) result,
                 Arrays.asList(
                         new Time(new BigDecimal("0.0"), 12, 10, 59, 456),
                         new Time(new BigDecimal("0.0"), 13, 10, 59, 456),
@@ -306,7 +306,7 @@ public class CqlTestSuite {
         result = context.resolveExpressionRef("List_QuantityList").evaluate(context);
         Assert.assertTrue(result instanceof Iterable);
         listComp = CqlList.equal(
-                (Iterable) result,
+                (Iterable<?>) result,
                 Arrays.asList(
                         new Quantity().withValue(new BigDecimal("1.0")).withUnit("m"),
                         new Quantity().withValue(new BigDecimal("2.1")).withUnit("m"),
@@ -318,7 +318,7 @@ public class CqlTestSuite {
         result = context.resolveExpressionRef("List_CodeList").evaluate(context);
         Assert.assertTrue(result instanceof Iterable);
         listComp = CqlList.equal(
-                (Iterable) result,
+                (Iterable<?>) result,
                 Arrays.asList(
                         new Code().withCode("12345").withSystem("http://loinc.org").withVersion("1").withDisplay("Test Code"),
                         new Code().withCode("123456").withSystem("http://loinc.org").withVersion("1").withDisplay("Another Test Code")
@@ -329,7 +329,7 @@ public class CqlTestSuite {
         result = context.resolveExpressionRef("List_ConceptList").evaluate(context);
         Assert.assertTrue(result instanceof Iterable);
         listComp = CqlList.equal(
-                (Iterable) result,
+                (Iterable<?>) result,
                 Arrays.asList(
                         new Concept().withCode(
                                 new Code().withCode("12345").withSystem("http://loinc.org").withVersion("1").withDisplay("Test Code")
@@ -351,7 +351,7 @@ public class CqlTestSuite {
         result = context.resolveExpressionRef("List_TupleList").evaluate(context);
         Assert.assertTrue(result instanceof Iterable);
         listComp = CqlList.equal(
-                (Iterable) result,
+                (Iterable<?>) result,
                 Arrays.asList(
                         new Tuple().withElements(elements), new Tuple().withElements(elements2)
 
@@ -362,7 +362,7 @@ public class CqlTestSuite {
         result = context.resolveExpressionRef("List_ListList").evaluate(context);
         Assert.assertTrue(result instanceof Iterable);
         listComp = CqlList.equal(
-                (Iterable) result,
+                (Iterable<?>) result,
                 Arrays.asList(Arrays.asList(1,2,3), Arrays.asList("a", "b", "c"))
         );
         Assert.assertTrue(listComp != null && listComp);
@@ -370,7 +370,7 @@ public class CqlTestSuite {
         result = context.resolveExpressionRef("List_IntervalList").evaluate(context);
         Assert.assertTrue(result instanceof Iterable);
         listComp = CqlList.equal(
-                (Iterable) result,
+                (Iterable<?>) result,
                 Arrays.asList(
                         new Interval(1, true, 5, true), new Interval(5, false, 9, false), new Interval(8, true, 10, false)
                 )
@@ -379,12 +379,12 @@ public class CqlTestSuite {
 
         result = context.resolveExpressionRef("List_MixedList").evaluate(context);
         Assert.assertTrue(result instanceof Iterable);
-        listComp = CqlList.equal((Iterable) result, Arrays.asList(1, "two", 3));
+        listComp = CqlList.equal((Iterable<?>) result, Arrays.asList(1, "two", 3));
         Assert.assertTrue(listComp != null && listComp);
 
         result = context.resolveExpressionRef("List_EmptyList").evaluate(context);
         Assert.assertTrue(result instanceof Iterable);
-        listComp = CqlList.equal((Iterable) result, Collections.EMPTY_LIST);
+        listComp = CqlList.equal((Iterable<?>) result, Collections.EMPTY_LIST);
         Assert.assertTrue(listComp != null && listComp);
     }
 

--- a/cql-engine/src/test/java/org/opencds/cqf/cql/execution/CqlTypesTest.java
+++ b/cql-engine/src/test/java/org/opencds/cqf/cql/execution/CqlTypesTest.java
@@ -26,6 +26,7 @@ import org.testng.annotations.Test;
 public class CqlTypesTest extends CqlExecutionTestBase {
 
     @Test
+    @SuppressWarnings("serial")
     public void testAny() throws JAXBException {
         Context context = new Context(library);
 

--- a/cql-engine/src/test/java/org/opencds/cqf/cql/execution/ElmTests.java
+++ b/cql-engine/src/test/java/org/opencds/cqf/cql/execution/ElmTests.java
@@ -31,13 +31,13 @@ public class ElmTests {
         Context context = new Context(library);
         Object result = context.resolveExpressionRef("TestFilter").getExpression().evaluate(context);
 
-        Assert.assertTrue(((List) result).size() == 2);
+        Assert.assertTrue(((List<?>) result).size() == 2);
     }
 
     @Test
     public void TestLibraryLoad() {
         try {
-            Library library = CqlLibraryReader.read(ElmTests.class.getResourceAsStream("CMS53Draft/PrimaryPCIReceivedWithin90MinutesofHospitalArrival-7.0.001.xml"));
+            CqlLibraryReader.read(ElmTests.class.getResourceAsStream("CMS53Draft/PrimaryPCIReceivedWithin90MinutesofHospitalArrival-7.0.001.xml"));
         } catch (IOException | JAXBException e) {
             throw new IllegalArgumentException("Error reading ELM: " + e.getMessage());
         }

--- a/cql-engine/src/test/java/org/opencds/cqf/cql/execution/Issue208.java
+++ b/cql-engine/src/test/java/org/opencds/cqf/cql/execution/Issue208.java
@@ -12,21 +12,21 @@ public class Issue208 extends CqlExecutionTestBase {
         Context context = new Context(library);
 
         Object result = context.resolveExpressionRef("Let Test 1").getExpression().evaluate(context);
-        Assert.assertTrue(EquivalentEvaluator.equivalent(((List)(((List) result).get(0))).get(0), 1));
-        Assert.assertTrue(EquivalentEvaluator.equivalent(((List)(((List) result).get(0))).get(1), 2));
-        Assert.assertTrue(EquivalentEvaluator.equivalent(((List)(((List) result).get(0))).get(2), 3));
+        Assert.assertTrue(EquivalentEvaluator.equivalent(((List<?>)(((List<?>) result).get(0))).get(0), 1));
+        Assert.assertTrue(EquivalentEvaluator.equivalent(((List<?>)(((List<?>) result).get(0))).get(1), 2));
+        Assert.assertTrue(EquivalentEvaluator.equivalent(((List<?>)(((List<?>) result).get(0))).get(2), 3));
 
-        Assert.assertTrue(EquivalentEvaluator.equivalent(((List)(((List) result).get(1))).get(0), 4));
-        Assert.assertTrue(EquivalentEvaluator.equivalent(((List)(((List) result).get(1))).get(1), 5));
-        Assert.assertTrue(EquivalentEvaluator.equivalent(((List)(((List) result).get(1))).get(2), 6));
+        Assert.assertTrue(EquivalentEvaluator.equivalent(((List<?>)(((List<?>) result).get(1))).get(0), 4));
+        Assert.assertTrue(EquivalentEvaluator.equivalent(((List<?>)(((List<?>) result).get(1))).get(1), 5));
+        Assert.assertTrue(EquivalentEvaluator.equivalent(((List<?>)(((List<?>) result).get(1))).get(2), 6));
 
         result = context.resolveExpressionRef("Let Test 2").getExpression().evaluate(context);
-        Assert.assertTrue(EquivalentEvaluator.equivalent(((List)(((List) result).get(0))).get(0), 1));
-        Assert.assertTrue(EquivalentEvaluator.equivalent(((List)(((List) result).get(0))).get(1), 2));
-        Assert.assertTrue(EquivalentEvaluator.equivalent(((List)(((List) result).get(0))).get(2), 3));
+        Assert.assertTrue(EquivalentEvaluator.equivalent(((List<?>)(((List<?>) result).get(0))).get(0), 1));
+        Assert.assertTrue(EquivalentEvaluator.equivalent(((List<?>)(((List<?>) result).get(0))).get(1), 2));
+        Assert.assertTrue(EquivalentEvaluator.equivalent(((List<?>)(((List<?>) result).get(0))).get(2), 3));
 
-        Assert.assertTrue(EquivalentEvaluator.equivalent(((List)(((List) result).get(1))).get(0), 4));
-        Assert.assertTrue(EquivalentEvaluator.equivalent(((List)(((List) result).get(1))).get(1), 5));
-        Assert.assertTrue(EquivalentEvaluator.equivalent(((List)(((List) result).get(1))).get(2), 6));
+        Assert.assertTrue(EquivalentEvaluator.equivalent(((List<?>)(((List<?>) result).get(1))).get(0), 4));
+        Assert.assertTrue(EquivalentEvaluator.equivalent(((List<?>)(((List<?>) result).get(1))).get(1), 5));
+        Assert.assertTrue(EquivalentEvaluator.equivalent(((List<?>)(((List<?>) result).get(1))).get(2), 6));
     }
 }

--- a/cql-engine/src/test/java/org/opencds/cqf/cql/execution/Issue223.java
+++ b/cql-engine/src/test/java/org/opencds/cqf/cql/execution/Issue223.java
@@ -13,12 +13,12 @@ public class Issue223 extends CqlExecutionTestBase {
         Context context = new Context(library);
 
         Object result = context.resolveExpressionRef("Access Flattened List of List Items").getExpression().evaluate(context);
-        List list = (List)result;
+        List<?> list = (List<?>)result;
         assertThat(list.size(), is(1));
         assertThat(list.get(0), is(true));
 
         result = context.resolveExpressionRef("Access Flattened List of List Items in a Single Query").getExpression().evaluate(context);
-        list = (List)result;
+        list = (List<?>)result;
         assertThat(list.size(), is(1));
         assertThat(list.get(0), is(true));
     }

--- a/cql-engine/src/test/java/org/opencds/cqf/cql/execution/LetClauseOutsideQueryContextTest.java
+++ b/cql-engine/src/test/java/org/opencds/cqf/cql/execution/LetClauseOutsideQueryContextTest.java
@@ -12,9 +12,9 @@ public class LetClauseOutsideQueryContextTest extends CqlExecutionTestBase {
         Context context = new Context(library);
 
         Object result = context.resolveExpressionRef("First Position of list").getExpression().evaluate(context);
-        Assert.assertTrue(EquivalentEvaluator.equivalent(((List)result).get(0), 1));
+        Assert.assertTrue(EquivalentEvaluator.equivalent(((List<?>)result).get(0), 1));
         
         result = context.resolveExpressionRef("Third Position of list With Same Name of Let As First").getExpression().evaluate(context);
-        Assert.assertTrue(EquivalentEvaluator.equivalent(((List)result).get(0), 3));
+        Assert.assertTrue(EquivalentEvaluator.equivalent(((List<?>)result).get(0), 3));
     }
 }

--- a/cql-engine/src/test/java/org/opencds/cqf/cql/execution/SortDescendingTest.java
+++ b/cql-engine/src/test/java/org/opencds/cqf/cql/execution/SortDescendingTest.java
@@ -12,9 +12,9 @@ public class SortDescendingTest extends CqlExecutionTestBase {
         Context context = new Context(library);
         
         Object result = context.resolveExpressionRef("sorted list of numbers descending").getExpression().evaluate(context);
-        Assert.assertTrue(EquivalentEvaluator.equivalent(((List) result).get(0), 9));
-        Assert.assertTrue(EquivalentEvaluator.equivalent(((List) result).get(1), 4));
-        Assert.assertTrue(EquivalentEvaluator.equivalent(((List) result).get(2), 2));
-        Assert.assertTrue(EquivalentEvaluator.equivalent(((List) result).get(3), 1));
+        Assert.assertTrue(EquivalentEvaluator.equivalent(((List<?>) result).get(0), 9));
+        Assert.assertTrue(EquivalentEvaluator.equivalent(((List<?>) result).get(1), 4));
+        Assert.assertTrue(EquivalentEvaluator.equivalent(((List<?>) result).get(2), 2));
+        Assert.assertTrue(EquivalentEvaluator.equivalent(((List<?>) result).get(3), 1));
     }
 }


### PR DESCRIPTION
* Parameterized raw types
* Fixed spelling
* Adding serialization version Id.

Partially resolves cqframework/clinical_quality_language#985 

This gets the build down to about ~130 warnings. They are almost all in the FHIR path tests.