### PR TITLE
Use Eclipse Moxy JAXB implementation

### DIFF
--- a/engine.fhir/src/test/resources/org/hl7/fhirpath/tests/jaxb.properties
+++ b/engine.fhir/src/test/resources/org/hl7/fhirpath/tests/jaxb.properties
@@ -1,0 +1,1 @@
+javax.xml.bind.context.factory=org.eclipse.persistence.jaxb.JAXBContextFactory

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -23,8 +23,8 @@
             <artifactId>jaxb2-basics</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.jaxb</groupId>
-            <artifactId>jaxb-runtime</artifactId>
+            <groupId>org.eclipse.persistence</groupId>
+            <artifactId>org.eclipse.persistence.moxy</artifactId>
         </dependency>
         <dependency>
             <groupId>com.google.code.findbugs</groupId>

--- a/engine/src/main/java/org/opencds/cqf/cql/engine/elm/execution/ObjectFactoryEx.java
+++ b/engine/src/main/java/org/opencds/cqf/cql/engine/elm/execution/ObjectFactoryEx.java
@@ -1,6 +1,9 @@
 package org.opencds.cqf.cql.engine.elm.execution;
 
+import javax.xml.bind.JAXBElement;
+import javax.xml.bind.annotation.XmlElementDecl;
 import javax.xml.bind.annotation.XmlRegistry;
+import javax.xml.namespace.QName;
 
 import org.cqframework.cql.elm.execution.*;
 
@@ -551,4 +554,12 @@ public class ObjectFactoryEx extends org.cqframework.cql.elm.execution.ObjectFac
 
     @Override
     public Xor createXor() { return new XorEvaluator(); }
+
+    // The JAXB implementations does not recursively search the superclass for annotations
+    @Override
+    @XmlElementDecl(namespace = "urn:hl7-org:elm:r1", name = "library")
+    public JAXBElement<Library> createLibrary(Library value) {
+        return new JAXBElement<Library>(new QName("urn:hl7-org:elm:r1", "library"), Library.class, null, value);
+    }
+
 }

--- a/engine/src/main/java/org/opencds/cqf/cql/engine/execution/CqlLibraryReader.java
+++ b/engine/src/main/java/org/opencds/cqf/cql/engine/execution/CqlLibraryReader.java
@@ -16,7 +16,6 @@ import javax.xml.transform.Source;
 import javax.xml.transform.stream.StreamSource;
 
 import org.cqframework.cql.elm.execution.Library;
-import org.cqframework.cql.elm.execution.ObjectFactory;
 import org.opencds.cqf.cql.engine.elm.execution.ObjectFactoryEx;
 import org.opencds.cqf.cql.engine.exception.CqlException;
 
@@ -27,26 +26,13 @@ public class CqlLibraryReader {
 
     // Performance enhancement additions ~ start
     public synchronized static Unmarshaller getUnmarshaller() throws JAXBException {
-        // This is supposed to work based on this link:
-        // https://jaxb.java.net/2.2.11/docs/ch03.html#compiling-xml-schema-adding-behaviors
-        // Override the unmarshal to use the XXXEvaluator classes
-        // This doesn't work exactly how it's described in the link above, but this is functional
         if (context == null)
         {
-            context = JAXBContext.newInstance(ObjectFactory.class);
+            context = JAXBContext.newInstance(ObjectFactoryEx.class);
         }
 
         if (unmarshaller == null) {
             unmarshaller = context.createUnmarshaller();
-            try {
-                // https://bugs.eclipse.org/bugs/show_bug.cgi?id=406032
-                //https://javaee.github.io/jaxb-v2/doc/user-guide/ch03.html#compiling-xml-schema-adding-behaviors
-                // for jre environment
-                unmarshaller.setProperty("com.sun.xml.bind.ObjectFactory", new ObjectFactoryEx());
-            } catch (javax.xml.bind.PropertyException e) {
-                // for jdk environment
-                unmarshaller.setProperty("com.sun.xml.internal.bind.ObjectFactory", new ObjectFactoryEx());
-            }
         }
 
         return unmarshaller;
@@ -107,11 +93,8 @@ public class CqlLibraryReader {
         return read(toSource(reader));
     }
 
-    @SuppressWarnings("unchecked")
     public synchronized static Library read(Source source) throws JAXBException {
-        Unmarshaller u = getUnmarshaller();
-        Object result = u.unmarshal(source);
-        return ((JAXBElement<Library>)result).getValue();
+        return read(getUnmarshaller(), source);
     }
 
     /**

--- a/engine/src/main/resources/org/opencds/cqf/cql/engine/elm/execution/jaxb.properties
+++ b/engine/src/main/resources/org/opencds/cqf/cql/engine/elm/execution/jaxb.properties
@@ -1,0 +1,1 @@
+javax.xml.bind.context.factory=org.eclipse.persistence.jaxb.JAXBContextFactory

--- a/pom.xml
+++ b/pom.xml
@@ -92,9 +92,9 @@
             </dependency>
 
             <dependency>
-                <groupId>org.glassfish.jaxb</groupId>
-                <artifactId>jaxb-runtime</artifactId>
-                <version>2.4.0-b180830.0438</version>
+                <groupId>org.eclipse.persistence</groupId>
+                <artifactId>org.eclipse.persistence.moxy</artifactId>
+                <version>2.7.7</version>
             </dependency>
 
             <dependency>
@@ -204,17 +204,6 @@
                 <!-- The scope of this dependency must remain as test.
             There is an intentional separation between the CQL translator and the CQL engine -->
                 <scope>test</scope>
-                <!-- These are excluded because the engine is using the org.glassfish implmentation of jaxb, at a newer version -->
-                <exclusions>
-                    <exclusion>
-                        <groupId>com.sun.xml.bind</groupId>
-                        <artifactId>jaxb-core</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>com.sun.xml.bind</groupId>
-                        <artifactId>jaxb-impl</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.testng</groupId>


### PR DESCRIPTION
* This makes the cql-engine use the same implementation jaxb as the cql-translator. This reduces package conflicts and ensures consistent behavior across the two projects.