### PR TITLE
🌎 Make tests pass in any timezone

### DIFF
--- a/cql-engine/src/test/java/org/opencds/cqf/cql/execution/CqlTestSuite.java
+++ b/cql-engine/src/test/java/org/opencds/cqf/cql/execution/CqlTestSuite.java
@@ -12,9 +12,15 @@ import org.fhir.ucum.UcumEssenceService;
 import org.fhir.ucum.UcumException;
 import org.fhir.ucum.UcumService;
 import org.opencds.cqf.cql.runtime.*;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
+import org.testng.IObjectFactory;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.ObjectFactory;
 import org.testng.annotations.Test;
 
 import javax.xml.bind.JAXBException;
@@ -23,6 +29,7 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.math.BigDecimal;
 import java.net.URLDecoder;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -30,10 +37,24 @@ import java.util.HashMap;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.powermock.api.mockito.PowerMockito.when;
 
+@PrepareForTest(TemporalHelper.class)
+@PowerMockIgnore({ "org.mockito.*", "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.*", "com.sun.org.apache.xalan.*"})
 public class CqlTestSuite {
 
     private final static Logger logger = LoggerFactory.getLogger(CqlTestSuite.class);
+
+    @ObjectFactory
+    public IObjectFactory getObjectFactory() {
+        return new org.powermock.modules.testng.PowerMockObjectFactory();
+    }
+
+    @BeforeMethod
+    public void beforeEachTestMethod() throws JAXBException, IOException, UcumException {
+        PowerMockito.spy(TemporalHelper.class);
+        when(TemporalHelper.getDefaultZoneOffset()).thenReturn(ZoneOffset.of("-06:00"));
+    }
 
     // This test is for the various CQL operators
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <jackson_version>2.10.1</jackson_version>
         <cqframework.version>1.3.19</cqframework.version>
+        <powermock.version>2.0.2</powermock.version>
     </properties>
 
     <repositories>
@@ -108,6 +109,18 @@
             <groupId>uk.co.datumedge</groupId>
             <artifactId>hamcrest-json</artifactId>
             <version>0.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-testng</artifactId>
+            <version>${powermock.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito2</artifactId>
+            <version>${powermock.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
The tests use the system timezone during date calculations, which causes them to fail when run at Pacific time (`-08:00`). This PR adds as spy on `TemporalHelper.getDefaultZoneOffset()` and makes it return a fixed timezone (`-06:00`).

To reproduce the error, set the fixed timezone to `-08:00` and run the tests.