### PR TITLE
#406 add parameters to current library context

### DIFF
--- a/engine/src/main/java/org/opencds/cqf/cql/engine/execution/CqlEngine.java
+++ b/engine/src/main/java/org/opencds/cqf/cql/engine/execution/CqlEngine.java
@@ -193,6 +193,10 @@ public class CqlEngine {
         }
 
         if (parameters != null) {
+            for (Map.Entry<String, Object> parameterValue : parameters.entrySet()) {
+               context.setParameter(library.getLocalId(), parameterValue.getKey(), parameterValue.getValue());
+            }
+
             if (library.getIncludes() != null && library.getIncludes().getDef() != null) {
                 for (IncludeDef def : library.getIncludes().getDef()) {
                     String name = def.getLocalIdentifier();

--- a/engine/src/test/java/org/opencds/cqf/cql/engine/execution/CqlEngineTests.java
+++ b/engine/src/test/java/org/opencds/cqf/cql/engine/execution/CqlEngineTests.java
@@ -96,6 +96,26 @@ public class CqlEngineTests {
         assertThat(expResult, is(10));
     }
 
+    @Test
+    public void test_simpleLibraryWithParam_returnsParamValue() throws IOException, JAXBException {
+        Library library = this.toLibrary("library Test version '1.0.0'\nparameter IntValue Integer\ndefine X:\nIntValue");
+
+        LibraryLoader libraryLoader = new InMemoryLibraryLoader(Collections.singleton(library));
+
+        CqlEngine engine = new CqlEngine(libraryLoader);
+
+        Map<String,Object> parameters = new HashMap<>();
+        parameters.put("IntValue", 10);
+
+        EvaluationResult result = engine.evaluate("Test", parameters);
+
+
+        Object expResult = result.forExpression("X");
+
+        assertThat(expResult, is(10));
+    }
+
+
     //@Test(expected = IllegalArgumentException.class)
     public void test_dataLibrary_noProvider_throwsException() throws IOException, JAXBException {
         Library library = this.toLibrary("library Test version '1.0.0'\nusing FHIR version '3.0.0'\ndefine X:\n5+5");


### PR DESCRIPTION
Parameter values were not being set for the "null" context and thus unavailable to the root library. Added a small loop to setParametersForContext(...) to add them to the current library context (which is the null context).