### PR TITLE
#413 - fix NPE in Quantity Interval with different UOM

### DIFF
--- a/engine/src/main/java/org/opencds/cqf/cql/engine/runtime/Interval.java
+++ b/engine/src/main/java/org/opencds/cqf/cql/engine/runtime/Interval.java
@@ -49,8 +49,11 @@ public class Interval implements CqlType, Comparable<Interval> {
             }
         }
 
-        else if (low != null && high != null && GreaterEvaluator.greater(getStart(), getEnd())) {
-            throw new InvalidInterval("Invalid Interval - the ending boundary must be greater than or equal to the starting boundary.");
+        else if (low != null && high != null ) {
+            Boolean isStartGreater = GreaterEvaluator.greater(getStart(), getEnd());
+            if( isStartGreater == null || isStartGreater.equals(Boolean.TRUE) ) {
+                throw new InvalidInterval("Invalid Interval - the ending boundary must be greater than or equal to the starting boundary.");
+            }
         }
     }
 

--- a/engine/src/test/java/org/opencds/cqf/cql/engine/execution/RuntimeTests.java
+++ b/engine/src/test/java/org/opencds/cqf/cql/engine/execution/RuntimeTests.java
@@ -8,8 +8,10 @@ import java.math.BigDecimal;
 
 import org.opencds.cqf.cql.engine.debug.Location;
 import org.opencds.cqf.cql.engine.debug.SourceLocator;
+import org.opencds.cqf.cql.engine.runtime.Interval;
 import org.opencds.cqf.cql.engine.runtime.Quantity;
 import org.opencds.cqf.cql.engine.runtime.Tuple;
+import org.opencds.cqf.cql.engine.exception.InvalidInterval;
 import org.testng.annotations.Test;
 
 public class RuntimeTests {
@@ -26,6 +28,13 @@ public class RuntimeTests {
 
         q = new Quantity().withValue(new BigDecimal("0.05")).withUnit("mg");
         assertThat(q.toString(), is("0.05 'mg'"));
+    }
+
+    @Test(expectedExceptions=InvalidInterval.class)
+    public void testIntervalOfQuantityWithDifferentUOM() {
+        Quantity s= new Quantity().withValue(new BigDecimal(10)).withUnit("mg/mL");
+        Quantity e = new Quantity().withValue(new BigDecimal(10)).withUnit("kg/m3");
+        Interval i = new Interval( s, true, e, true );
     }
 
     @Test


### PR DESCRIPTION
When creating an Interval of quantity values and the quantity UOMs are different, the Interval constructor throws a NullPointerException. The problem is that GreaterEvaluator.evaluate() can return null and the Interval constructor wants to use that in a primitive boolean context. I added some guarding for the nulls so that a more reasonable error message comes out. It lacks the detail about the differing UOMs, but is easier to understand as data related vs. the NPE.