### PR TITLE
Adding evaluation support for Concepts

### DIFF
--- a/engine/src/main/java/org/opencds/cqf/cql/engine/elm/execution/CodeDefEvaluator.java
+++ b/engine/src/main/java/org/opencds/cqf/cql/engine/elm/execution/CodeDefEvaluator.java
@@ -9,6 +9,6 @@ public class CodeDefEvaluator extends org.cqframework.cql.elm.execution.CodeDef 
     @Override
     protected Object internalEvaluate(Context context) {
         CodeSystemInfo info = (CodeSystemInfo) getCodeSystem().evaluate(context);
-        return new Code().withCode(this.getId()).withSystem(info.getId()).withDisplay(this.getDisplay());
+        return new Code().withCode(this.getId()).withSystem(info.getId()).withDisplay(this.getDisplay()).withVersion(info.getVersion());
     }
 }

--- a/engine/src/main/java/org/opencds/cqf/cql/engine/elm/execution/ConceptDefEvaluator.java
+++ b/engine/src/main/java/org/opencds/cqf/cql/engine/elm/execution/ConceptDefEvaluator.java
@@ -1,0 +1,24 @@
+package org.opencds.cqf.cql.engine.elm.execution;
+
+import org.cqframework.cql.elm.execution.CodeRef;
+import org.opencds.cqf.cql.engine.execution.Context;
+import org.opencds.cqf.cql.engine.runtime.Code;
+import org.opencds.cqf.cql.engine.runtime.Concept;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ConceptDefEvaluator extends org.cqframework.cql.elm.execution.ConceptDef {
+
+    @Override
+    protected Object internalEvaluate(Context context) {
+        List<Code> codeList = this.getCode().stream()
+                .map(CodeRef::getName)
+                .map(context::resolveCodeRef)
+                .map(codeDef -> codeDef.evaluate(context))
+                .map(object -> (Code)object)
+                .collect(Collectors.toList());
+
+        return new Concept().withDisplay(this.getDisplay()).withCodes(codeList);
+    }
+}

--- a/engine/src/main/java/org/opencds/cqf/cql/engine/elm/execution/ConceptRefEvaluator.java
+++ b/engine/src/main/java/org/opencds/cqf/cql/engine/elm/execution/ConceptRefEvaluator.java
@@ -1,0 +1,18 @@
+package org.opencds.cqf.cql.engine.elm.execution;
+
+import org.opencds.cqf.cql.engine.execution.Context;
+
+public class ConceptRefEvaluator extends org.cqframework.cql.elm.execution.ConceptRef {
+
+    @Override
+    protected Object internalEvaluate(Context context) {
+        boolean enteredLibrary = context.enterLibrary(this.getLibraryName());
+        try {
+            return context.resolveConceptRef(this.getName()).evaluate(context);
+        }
+        finally {
+            context.exitLibrary(enteredLibrary);
+        }
+    }
+
+}

--- a/engine/src/main/java/org/opencds/cqf/cql/engine/elm/execution/ObjectFactoryEx.java
+++ b/engine/src/main/java/org/opencds/cqf/cql/engine/elm/execution/ObjectFactoryEx.java
@@ -88,6 +88,12 @@ public class ObjectFactoryEx extends org.cqframework.cql.elm.execution.ObjectFac
     public Concept createConcept() { return new ConceptEvaluator(); }
 
     @Override
+    public ConceptDef createConceptDef() { return new ConceptDefEvaluator(); }
+
+    @Override
+    public ConceptRef createConceptRef() { return new ConceptRefEvaluator(); }
+
+    @Override
     public Contains createContains() { return new ContainsEvaluator(); }
 
     @Override

--- a/engine/src/main/java/org/opencds/cqf/cql/engine/execution/Context.java
+++ b/engine/src/main/java/org/opencds/cqf/cql/engine/execution/Context.java
@@ -14,6 +14,7 @@ import javax.xml.namespace.QName;
 import org.cqframework.cql.elm.execution.ChoiceTypeSpecifier;
 import org.cqframework.cql.elm.execution.CodeDef;
 import org.cqframework.cql.elm.execution.CodeSystemDef;
+import org.cqframework.cql.elm.execution.ConceptDef;
 import org.cqframework.cql.elm.execution.ExpressionDef;
 import org.cqframework.cql.elm.execution.FunctionDef;
 import org.cqframework.cql.elm.execution.IncludeDef;
@@ -295,6 +296,16 @@ public class Context {
         }
 
         throw new CqlException(String.format("Could not resolve code reference '%s'.", name));
+    }
+
+    public ConceptDef resolveConceptRef(String name) {
+        for (ConceptDef conceptDef : getCurrentLibrary().getConcepts().getDef()) {
+            if (conceptDef.getName().equals(name)) {
+                return conceptDef;
+            }
+        }
+
+        throw new CqlException(String.format("Could not resolve concept reference '%s'.", name));
     }
 
     private IncludeDef resolveLibraryRef(String libraryName) {

--- a/engine/src/test/java/org/opencds/cqf/cql/engine/execution/CqlConceptTest.java
+++ b/engine/src/test/java/org/opencds/cqf/cql/engine/execution/CqlConceptTest.java
@@ -1,0 +1,63 @@
+package org.opencds.cqf.cql.engine.execution;
+
+import org.opencds.cqf.cql.engine.exception.CqlException;
+import org.opencds.cqf.cql.engine.runtime.Code;
+import org.opencds.cqf.cql.engine.runtime.Concept;
+import org.opencds.cqf.cql.engine.runtime.CqlType;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class CqlConceptTest extends CqlExecutionTestBase {
+
+    @Test
+    public void testConceptRef() {
+        Context ctx = new Context(library);
+
+        List<Code> codes = Arrays.asList(
+                createCode("123", "1"),
+                createCode("234", "1"),
+                createCode("abc", "a")
+        );
+        Concept expected = new Concept()
+                .withDisplay("test-concept-display")
+                .withCodes(codes);
+
+        CqlType actual = (CqlType)ctx.resolveExpressionRef("testConceptRef").getExpression().evaluate(ctx);
+
+        assertEqual(expected, actual);
+    }
+
+    @Test
+    public void testResolveConceptRef_noConceptFound() {
+        Context context = new Context(library);
+
+        try {
+            context.resolveConceptRef("invalid-concept");
+            Assert.fail("Did not hit expected exception");
+        }
+        catch (CqlException e) {
+            if (!e.getMessage().startsWith("Could not resolve concept reference")) {
+                Assert.fail("Unexpected exception message");
+            }
+        }
+    }
+
+    private static Code createCode(String prefix, String systemVal) {
+        return new Code()
+                .withCode(prefix + "-value")
+                .withSystem("http://system-" + systemVal + ".org")
+                .withVersion(systemVal)
+                .withDisplay(prefix + "-display");
+    }
+
+    static void assertEqual(CqlType expected, CqlType actual) {
+        if (!expected.equal(actual)) {
+            String message = "Expected " + expected + " but got " + actual;
+            Assert.fail(message);
+        }
+    }
+
+}

--- a/engine/src/test/java/org/opencds/cqf/cql/engine/execution/IncludedConceptRefTest.java
+++ b/engine/src/test/java/org/opencds/cqf/cql/engine/execution/IncludedConceptRefTest.java
@@ -1,0 +1,31 @@
+package org.opencds.cqf.cql.engine.execution;
+
+import org.opencds.cqf.cql.engine.runtime.Code;
+import org.opencds.cqf.cql.engine.runtime.Concept;
+import org.opencds.cqf.cql.engine.runtime.CqlType;
+import org.testng.annotations.Test;
+
+import java.util.Collections;
+
+public class IncludedConceptRefTest extends CqlExecutionTestBase {
+
+    @Test
+    public void testIncludedConceptRef() {
+        Context ctx = new Context(library);
+        ctx.registerLibraryLoader(new TestLibraryLoader(getLibraryManager()));
+
+        Code code = new Code()
+                .withCode("code-value")
+                .withDisplay("code-display")
+                .withSystem("http://system.org")
+                .withVersion("1");
+        Concept expected = new Concept()
+                .withDisplay("concept-display")
+                .withCodes(Collections.singletonList(code));
+
+        CqlType actual = (CqlType)ctx.resolveExpressionRef("testIncludedConceptRef").getExpression().evaluate(ctx);
+
+        CqlConceptTest.assertEqual(expected, actual);
+    }
+
+}

--- a/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/CqlConceptTest.cql
+++ b/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/CqlConceptTest.cql
@@ -1,0 +1,12 @@
+library CqlConceptTest
+
+codesystem system1: 'http://system-1.org' version '1'
+codesystem systemA: 'http://system-a.org' version 'a'
+
+code code123: '123-value' from system1 display '123-display'
+code code234: '234-value' from system1 display '234-display'
+code codeAbc: 'abc-value' from systemA display 'abc-display'
+
+concept testConcept: { code123, code234, codeAbc } display 'test-concept-display'
+
+define testConceptRef: testConcept

--- a/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/IncludedConceptRefTest.cql
+++ b/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/IncludedConceptRefTest.cql
@@ -1,0 +1,5 @@
+library IncludedConceptRefTest
+
+include IncludedConceptRefTestCommon called Common
+
+define testIncludedConceptRef: Common.testConcept

--- a/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/IncludedConceptRefTestCommon.cql
+++ b/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/IncludedConceptRefTestCommon.cql
@@ -1,0 +1,7 @@
+library IncludedConceptRefTestCommon
+
+codesystem testSystem: 'http://system.org' version '1'
+
+code testCode: 'code-value' from testSystem display 'code-display'
+
+concept testConcept: { testCode } display 'concept-display'


### PR DESCRIPTION
resolves cqframework/clinical_quality_language#941

I tried to mimic CodeRefEvaluator and its related classes.

Extended CodeDefEvaluator to set the codesystem version per the CQL spec (https://cql.hl7.org/02-authorsguide.html#code).

I added the CodeDefEvaluator change purely to make my unit tests slightly more "complete".
Please let me know if there are any issues with setting that field, it's not required for the overall change set.