### PR TITLE
Update to latest hapi, jackson, ucum, and translator versions. Remove…

### DIFF
--- a/engine.fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/converter/Dstu2TypeConverterTests.java
+++ b/engine.fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/converter/Dstu2TypeConverterTests.java
@@ -1,10 +1,10 @@
 package org.opencds.cqf.cql.engine.fhir.converter;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.testng.Assert.assertTrue;
 
 import static org.hamcrest.Matchers.instanceOf;
 
@@ -587,7 +587,7 @@ public class Dstu2TypeConverterTests {
     @Test
     public void TestRangeToCqlInterval() {
         Interval expected = new Interval(new Quantity().withValue(new BigDecimal("2.0")).withUnit("ml"), true,
-        new Quantity().withValue(new BigDecimal("5.0")).withUnit("ml"), true); 
+        new Quantity().withValue(new BigDecimal("5.0")).withUnit("ml"), true);
         Interval actual = this.typeConverter
                 .toCqlInterval(new Range()
                 .setLow((SimpleQuantity)new org.hl7.fhir.dstu2.model.SimpleQuantity().setValue(new BigDecimal("2.0")).setUnit("ml").setSystem("http://unitsofmeasure.org"))

--- a/engine.fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/converter/Dstu3TypeConverterTests.java
+++ b/engine.fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/converter/Dstu3TypeConverterTests.java
@@ -1,10 +1,10 @@
 package org.opencds.cqf.cql.engine.fhir.converter;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.testng.Assert.assertTrue;
 
 import static org.hamcrest.Matchers.instanceOf;
 
@@ -587,7 +587,7 @@ public class Dstu3TypeConverterTests {
     @Test
     public void TestRangeToCqlInterval() {
         Interval expected = new Interval(new Quantity().withValue(new BigDecimal("2.0")).withUnit("ml"), true,
-        new Quantity().withValue(new BigDecimal("5.0")).withUnit("ml"), true); 
+        new Quantity().withValue(new BigDecimal("5.0")).withUnit("ml"), true);
         Interval actual = this.typeConverter
                 .toCqlInterval(new Range()
                 .setLow((SimpleQuantity)new org.hl7.fhir.dstu3.model.SimpleQuantity().setValue(2.0).setUnit("ml").setSystem("http://unitsofmeasure.org"))

--- a/engine.fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/converter/R4TypeConverterTests.java
+++ b/engine.fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/converter/R4TypeConverterTests.java
@@ -1,10 +1,10 @@
 package org.opencds.cqf.cql.engine.fhir.converter;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.testng.Assert.assertTrue;
 
 import static org.hamcrest.Matchers.instanceOf;
 
@@ -587,7 +587,7 @@ public class R4TypeConverterTests {
     @Test
     public void TestRangeToCqlInterval() {
         Interval expected = new Interval(new Quantity().withValue(new BigDecimal("2.0")).withUnit("ml"), true,
-        new Quantity().withValue(new BigDecimal("5.0")).withUnit("ml"), true); 
+        new Quantity().withValue(new BigDecimal("5.0")).withUnit("ml"), true);
         Interval actual = this.typeConverter
                 .toCqlInterval(new Range()
                 .setLow(new org.hl7.fhir.r4.model.Quantity(2.0).setUnit("ml").setSystem("http://unitsofmeasure.org"))

--- a/engine.fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/converter/R5TypeConverterTests.java
+++ b/engine.fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/converter/R5TypeConverterTests.java
@@ -1,10 +1,10 @@
 package org.opencds.cqf.cql.engine.fhir.converter;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.testng.Assert.assertTrue;
 
 import static org.hamcrest.Matchers.instanceOf;
 
@@ -587,7 +587,7 @@ public class R5TypeConverterTests {
     @Test
     public void TestRangeToCqlInterval() {
         Interval expected = new Interval(new Quantity().withValue(new BigDecimal("2.0")).withUnit("ml"), true,
-        new Quantity().withValue(new BigDecimal("5.0")).withUnit("ml"), true); 
+        new Quantity().withValue(new BigDecimal("5.0")).withUnit("ml"), true);
         Interval actual = this.typeConverter
                 .toCqlInterval(new Range()
                 .setLow(new org.hl7.fhir.r5.model.Quantity(2.0).setUnit("ml").setSystem("http://unitsofmeasure.org"))

--- a/engine.fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/model/TestDstu2ModelResolver.java
+++ b/engine.fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/model/TestDstu2ModelResolver.java
@@ -1,7 +1,7 @@
 package org.opencds.cqf.cql.engine.fhir.model;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 import static org.testng.AssertJUnit.assertTrue;
 
 import java.lang.reflect.Field;
@@ -139,8 +139,8 @@ public class TestDstu2ModelResolver {
                 enumFactory.setAccessible(true);
                 EnumFactory<?> factory = (EnumFactory<?>)enumFactory.get(instance);
 
-                assertTrue(factory.getClass().getSimpleName().replace("EnumFactory", "").equals(enumType.getSimpleName())); 
-            } 
+                assertTrue(factory.getClass().getSimpleName().replace("EnumFactory", "").equals(enumType.getSimpleName()));
+            }
             catch(Exception e){
                 throw new AssertionError("error getting factory type. " + e.getMessage());
             }
@@ -186,10 +186,10 @@ public class TestDstu2ModelResolver {
 
     // This is a serious failure that needs to be addressed. There's some sort of mixup
     // between the dstu2 and hl7org dstu2 objects.
-    // @Test 
+    // @Test
     public void resolveMissingPropertyReturnsNull() {
         ModelResolver resolver = new Dstu2FhirModelResolver();
-        
+
         Patient p = new Patient();
 
         Object result = resolver.resolvePath(p, "not-a-path");

--- a/engine.fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/model/TestDstu3ModelResolver.java
+++ b/engine.fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/model/TestDstu3ModelResolver.java
@@ -1,7 +1,7 @@
 package org.opencds.cqf.cql.engine.fhir.model;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 import static org.testng.AssertJUnit.assertTrue;
 
 import java.util.ArrayList;
@@ -131,14 +131,14 @@ public class TestDstu3ModelResolver {
             }
         }
     }
-    
+
     // This tests special case logic in the Model Resolver.
     // Ideally, these would all disappear with either registering custom types
     // on the FhirContext or generalized logic, or fixed-up ModelInfos
-    @Test 
+    @Test
     public void modelInfoSpecialCaseTests() {
         ModelResolver resolver = new Dstu3FhirModelResolver();
-                
+
         // This tests resolution of inner classes. They aren't registered directly.
         resolver.resolveType("TestScriptRequestMethodCode");
         resolver.resolveType("FHIRDeviceStatus");
@@ -198,7 +198,7 @@ public class TestDstu3ModelResolver {
             Enumeration<?> instance = (Enumeration<?>)resolver.createInstance(enumType.getSimpleName());
             assertNotNull(instance);
 
-            assertTrue(instance.getEnumFactory().getClass().getSimpleName().replace("EnumFactory", "").equals(enumType.getSimpleName())); 
+            assertTrue(instance.getEnumFactory().getClass().getSimpleName().replace("EnumFactory", "").equals(enumType.getSimpleName()));
         }
 
 
@@ -248,10 +248,10 @@ public class TestDstu3ModelResolver {
         assertTrue(path.equals("subject"));
     }
 
-    @Test 
+    @Test
     public void resolveMissingPropertyReturnsNull() {
         ModelResolver resolver = new Dstu3FhirModelResolver();
-        
+
         Patient p = new Patient();
 
         Object result = resolver.resolvePath(p, "not-a-path");

--- a/engine.fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/model/TestR4ModelResolver.java
+++ b/engine.fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/model/TestR4ModelResolver.java
@@ -1,9 +1,9 @@
 package org.opencds.cqf.cql.engine.fhir.model;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.testng.AssertJUnit.assertTrue;
 
 import java.util.ArrayList;
@@ -120,10 +120,10 @@ public class TestR4ModelResolver {
         }
     }
 
-    @Test 
+    @Test
     public void modelInfoSpecialCaseTests() {
         ModelResolver resolver = new R4FhirModelResolver();
-                
+
         // This tests resolution of inner classes. They aren't registered directly.
         resolver.resolveType("TestScriptRequestMethodCode");
         resolver.resolveType("FHIRDeviceStatus");
@@ -147,7 +147,7 @@ public class TestR4ModelResolver {
         resolver.resolveType("SampledDataDataType");
         resolver.resolveType("ClaimProcessingCodes");
         resolver.resolveType("ContractResourcePublicationStatusCodes");
-        
+
 
         // These are known glitches in the ModelInfo
         resolver.resolveType("vConfidentialityClassification");
@@ -222,7 +222,7 @@ public class TestR4ModelResolver {
                     continue;
                 }
 
-               
+
 
                 switch (ci.getBaseType()) {
                     // Abstract classes
@@ -281,7 +281,7 @@ public class TestR4ModelResolver {
             Enumeration<?> instance = (Enumeration<?>)resolver.createInstance(enumType.getSimpleName());
             assertNotNull(instance);
 
-            assertTrue(instance.getEnumFactory().getClass().getSimpleName().replace("EnumFactory", "").equals(enumType.getSimpleName())); 
+            assertTrue(instance.getEnumFactory().getClass().getSimpleName().replace("EnumFactory", "").equals(enumType.getSimpleName()));
         }
 
         // These are some inner classes that don't appear in the enums above
@@ -333,20 +333,20 @@ public class TestR4ModelResolver {
         assertTrue(path.equals("subject"));
     }
 
-    @Test 
+    @Test
     public void resolveMissingPropertyReturnsNull() {
         ModelResolver resolver = new R4FhirModelResolver();
-        
+
         Patient p = new Patient();
 
         Object result = resolver.resolvePath(p, "not-a-path");
         assertNull(result);
     }
 
-    @Test 
+    @Test
     public void resolveIdPropertyReturnsString() {
         ModelResolver resolver = new R4FhirModelResolver();
-        
+
         Patient p = new Patient();
         p.setId("5");
         IdType idType = p.getIdElement();
@@ -364,7 +364,7 @@ public class TestR4ModelResolver {
     public void resolveDateTimeProviderReturnsDate() {
 
         ModelResolver resolver = new R4FhirModelResolver();
-        
+
         VisionPrescription vp = new VisionPrescription();
         Date time = new GregorianCalendar(1999, 3, 31).getTime();
         vp.setDateWritten(time);

--- a/engine.fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/searchparam/TestSearchParameterResolver.java
+++ b/engine.fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/searchparam/TestSearchParameterResolver.java
@@ -1,8 +1,8 @@
 package org.opencds.cqf.cql.engine.fhir.searchparam;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.testng.annotations.Test;

--- a/engine/src/test/java/org/opencds/cqf/cql/engine/data/SystemDataProviderTest.java
+++ b/engine/src/test/java/org/opencds/cqf/cql/engine/data/SystemDataProviderTest.java
@@ -1,6 +1,6 @@
 package org.opencds.cqf.cql.engine.data;
 
-import static org.junit.Assert.assertNull;
+import static org.testng.Assert.assertNull;
 
 import org.opencds.cqf.cql.engine.runtime.Date;
 import org.testng.annotations.Test;
@@ -10,7 +10,7 @@ public class SystemDataProviderTest {
     @Test
     public void resolveMissingPropertyReturnsNull() {
         SystemDataProvider provider = new SystemDataProvider();
-        
+
         Date date = new Date(2019, 01, 01);
 
         Object result = provider.resolvePath(date, "notapath");

--- a/engine/src/test/java/org/opencds/cqf/cql/engine/execution/CqlEngineTests.java
+++ b/engine/src/test/java/org/opencds/cqf/cql/engine/execution/CqlEngineTests.java
@@ -2,8 +2,8 @@ package org.opencds.cqf.cql.engine.execution;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertEquals;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -21,12 +21,12 @@ import org.cqframework.cql.cql2elm.CqlTranslatorOptions;
 import org.cqframework.cql.cql2elm.LibraryManager;
 import org.cqframework.cql.cql2elm.model.TranslatedLibrary;
 import org.cqframework.cql.elm.execution.Library;
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 public class CqlEngineTests extends TranslatingTestBase {
 
-    
-    @Test(expected = IllegalArgumentException.class)
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
     public void test_nullLibraryLoader_throwsException() {
         new CqlEngine(null);
     }
@@ -41,7 +41,7 @@ public class CqlEngineTests extends TranslatingTestBase {
 
         EvaluationResult result = engine.evaluate("Test");
 
- 
+
         Object expResult = result.forExpression("X");
 
         assertThat(expResult, is(10));
@@ -78,7 +78,7 @@ public class CqlEngineTests extends TranslatingTestBase {
         engine.evaluate("Test");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expectedExceptions = IllegalArgumentException.class)
     public void test_terminologyLibrary_noProvider_throwsException() throws IOException, JAXBException {
         Library library = this.toLibrary("library Test version '1.0.0'\nvalueset valueset \"Dummy Value Set\": \"http://localhost\"\ndefine X:\n5+5");
 
@@ -128,7 +128,7 @@ public class CqlEngineTests extends TranslatingTestBase {
     public void test_twoLibraries_expressionsForEach() throws IOException, JAXBException {
 
         Map<org.hl7.elm.r1.VersionedIdentifier, String> libraries = new HashMap<>();
-        libraries.put(this.toElmIdentifier("Common", "1.0.0"), 
+        libraries.put(this.toElmIdentifier("Common", "1.0.0"),
             "library Common version '1.0.0'\ndefine Z:\n5+5\n");
         libraries.put(toElmIdentifier("Test", "1.0.0"),
             "library Test version '1.0.0'\ninclude Common version '1.0.0' named \"Common\"\ndefine X:\n5+5\ndefine Y: 2 + 2\ndefine W: \"Common\".Z + 5");

--- a/engine/src/test/java/org/opencds/cqf/cql/engine/execution/CqlLibraryTest.java
+++ b/engine/src/test/java/org/opencds/cqf/cql/engine/execution/CqlLibraryTest.java
@@ -2,8 +2,8 @@ package org.opencds.cqf.cql.engine.execution;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 
 
 import javax.xml.bind.JAXBException;

--- a/engine/src/test/java/org/opencds/cqf/cql/engine/execution/CqlValueLiteralsAndSelectorsTest.java
+++ b/engine/src/test/java/org/opencds/cqf/cql/engine/execution/CqlValueLiteralsAndSelectorsTest.java
@@ -11,7 +11,7 @@ import java.math.RoundingMode;
 
 import javax.xml.bind.JAXBException;
 
-import org.junit.Assert;
+import org.testng.Assert;
 import org.opencds.cqf.cql.engine.exception.CqlException;
 import org.opencds.cqf.cql.engine.runtime.Quantity;
 import org.testng.annotations.Test;

--- a/engine/src/test/java/org/opencds/cqf/cql/engine/execution/ExpressionCacheTest.java
+++ b/engine/src/test/java/org/opencds/cqf/cql/engine/execution/ExpressionCacheTest.java
@@ -2,8 +2,8 @@ package org.opencds.cqf.cql.engine.execution;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
 import org.cqframework.cql.elm.execution.VersionedIdentifier;
 import org.testng.annotations.Test;

--- a/engine/src/test/java/org/opencds/cqf/cql/engine/execution/IncludedCodeRefTest.java
+++ b/engine/src/test/java/org/opencds/cqf/cql/engine/execution/IncludedCodeRefTest.java
@@ -3,7 +3,7 @@ package org.opencds.cqf.cql.engine.execution;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertNotNull;
+import static org.testng.Assert.assertNotNull;
 
 
 import org.opencds.cqf.cql.engine.runtime.Code;

--- a/engine/src/test/java/org/opencds/cqf/cql/engine/execution/NamespaceHelperTests.java
+++ b/engine/src/test/java/org/opencds/cqf/cql/engine/execution/NamespaceHelperTests.java
@@ -1,9 +1,9 @@
 package org.opencds.cqf.cql.engine.execution;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 public class NamespaceHelperTests {
 

--- a/pom.xml
+++ b/pom.xml
@@ -44,9 +44,9 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <jackson.version>2.10.1</jackson.version>
-        <cqframework.version>1.5.1-SNAPSHOT</cqframework.version>
-        <hapi.version>5.0.2</hapi.version>
+        <jackson.version>2.12.1</jackson.version>
+        <cqframework.version>1.5.1</cqframework.version>
+        <hapi.version>5.2.0</hapi.version>
     </properties>
 
     <repositories>
@@ -123,7 +123,7 @@
             <dependency>
                 <groupId>org.fhir</groupId>
                 <artifactId>ucum</artifactId>
-                <version>1.0.2</version>
+                <version>1.0.3</version>
                 <exclusions>
                     <exclusion>
                         <groupId>xpp3</groupId>


### PR DESCRIPTION
* Update to latest HAPI Version
* Update to latest UCUM Service version
* Update to latest translator version
* We had inherited a junit test dependency from HAPI that was removed. Removed all usages of that and consolidated everything to testng. Now there's only one unit test framework in use.