### PR TITLE
Improve terminology provider error handling

### DIFF
--- a/engine.fhir/.gitignore
+++ b/engine.fhir/.gitignore
@@ -1,0 +1,1 @@
+/test-output/

--- a/engine.fhir/pom.xml
+++ b/engine.fhir/pom.xml
@@ -55,6 +55,11 @@
             <groupId>xpp3</groupId>
             <artifactId>xpp3_xpath</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock-jre8</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/engine.fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/terminology/R4FhirTerminologyProvider.java
+++ b/engine.fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/terminology/R4FhirTerminologyProvider.java
@@ -108,19 +108,19 @@ public class R4FhirTerminologyProvider implements TerminologyProvider {
                 .execute();
 
         StringType display = (StringType) respParam.getParameter("display");
+        if( display != null ) {
+        	code.withDisplay( display.getValue() );
+        }
 
-        return code.withSystem(codeSystem.getId())
-                .withDisplay(display != null ? display.getValue() : null );
+        return code.withSystem(codeSystem.getId());
     }
 
     public Boolean resolveByUrl(ValueSetInfo valueSet) {
         if (valueSet.getVersion() != null
                 || (valueSet.getCodeSystems() != null && valueSet.getCodeSystems().size() > 0)) {
-            if (!(valueSet.getCodeSystems().size() == 1 && valueSet.getCodeSystems().get(0).getVersion() == null)) {
-                throw new UnsupportedOperationException(String.format(
-                        "Could not expand value set %s; version and code system bindings are not supported at this time.",
-                        valueSet.getId()));
-            }
+            throw new UnsupportedOperationException(String.format(
+                    "Could not expand value set %s; version and code system bindings are not supported at this time.",
+                    valueSet.getId()));
         }
         
         if (valueSet.getId().startsWith("urn:oid:")) {
@@ -128,7 +128,7 @@ public class R4FhirTerminologyProvider implements TerminologyProvider {
         } else if (valueSet.getId().startsWith("http:") || valueSet.getId().startsWith("https:")) {
             Bundle searchResults = fhirClient.search().forResource(ValueSet.class)
                     .where(ValueSet.URL.matches().value(valueSet.getId())).returnBundle(Bundle.class).execute();
-            if (searchResults.isEmpty()) {
+            if (searchResults.getEntry().isEmpty()) {
                 throw new IllegalArgumentException(String.format("Could not resolve value set %s.", valueSet.getId()));
             } else if (searchResults.getEntry().size() == 1) {
                 valueSet.setId(searchResults.getEntryFirstRep().getResource().getIdElement().getIdPart());

--- a/engine.fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/terminology/R4FhirTerminologyProvider.java
+++ b/engine.fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/terminology/R4FhirTerminologyProvider.java
@@ -131,7 +131,7 @@ public class R4FhirTerminologyProvider implements TerminologyProvider {
             if (searchResults.isEmpty()) {
                 throw new IllegalArgumentException(String.format("Could not resolve value set %s.", valueSet.getId()));
             } else if (searchResults.getEntry().size() == 1) {
-                valueSet.setId(searchResults.getEntryFirstRep().getResource().getId());
+                valueSet.setId(searchResults.getEntryFirstRep().getResource().getIdElement().getIdPart());
             } else {
                 throw new IllegalArgumentException("Found more than 1 ValueSet with url: " + valueSet.getId());
             }

--- a/engine.fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/R4FhirTest.java
+++ b/engine.fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/R4FhirTest.java
@@ -145,7 +145,7 @@ public abstract class R4FhirTest {
         bundle.setTotal(resources != null ? resources.length : 0);
         if( resources != null ) {
             for (Resource l : resources) {
-                bundle.addEntry().setResource(l).setFullUrl("/" + l.getIdBase() + "/" + l.getId());
+                bundle.addEntry().setResource(l).setFullUrl("/" + l.fhirType() + "/" + l.getId());
             }
         }
         return bundle;

--- a/engine.fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/R4FhirTest.java
+++ b/engine.fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/R4FhirTest.java
@@ -30,7 +30,7 @@ import ca.uhn.fhir.rest.client.interceptor.LoggingInterceptor;
 public abstract class R4FhirTest {
     private static FhirContext FHIR_CONTEXT = FhirContext.forR4();
     private static IParser FHIR_PARSER = FHIR_CONTEXT.newJsonParser().setPrettyPrint(true);
-    private static int HTTP_PORT = 8080;
+    private static int HTTP_PORT = 0;
 
     // emulate wiremock's junit.WireMockRule with testng features
     WireMockServer wireMockServer;
@@ -38,7 +38,7 @@ public abstract class R4FhirTest {
     
     @BeforeMethod()
     public void start() {
-        wireMockServer = new WireMockServer();
+        wireMockServer = new WireMockServer(getHttpPort());
         wireMockServer.start();
         WireMock.configureFor("localhost", getHttpPort());
         wireMock = new WireMock("localhost", getHttpPort());

--- a/engine.fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/R4FhirTest.java
+++ b/engine.fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/R4FhirTest.java
@@ -1,0 +1,153 @@
+package org.opencds.cqf.cql.engine.fhir;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+
+import java.net.ServerSocket;
+import java.util.List;
+
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.CapabilityStatement;
+import org.hl7.fhir.r4.model.Enumerations;
+import org.hl7.fhir.r4.model.OperationOutcome;
+import org.hl7.fhir.r4.model.OperationOutcome.IssueSeverity;
+import org.hl7.fhir.r4.model.Resource;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.MappingBuilder;
+import com.github.tomakehurst.wiremock.client.WireMock;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.parser.IParser;
+import ca.uhn.fhir.rest.client.api.IGenericClient;
+import ca.uhn.fhir.rest.client.interceptor.LoggingInterceptor;
+
+public abstract class R4FhirTest {
+    private static FhirContext FHIR_CONTEXT = FhirContext.forR4();
+    private static IParser FHIR_PARSER = FHIR_CONTEXT.newJsonParser().setPrettyPrint(true);
+    private static int HTTP_PORT = 8080;
+
+    // emulate wiremock's junit.WireMockRule with testng features
+    WireMockServer wireMockServer;
+    WireMock wireMock;
+    
+    @BeforeMethod()
+    public void start() {
+        wireMockServer = new WireMockServer();
+        wireMockServer.start();
+        WireMock.configureFor("localhost", getHttpPort());
+        wireMock = new WireMock("localhost", getHttpPort());
+        
+        mockFhirRead( "/metadata", getCapabilityStatement() );
+    }
+    
+    @AfterMethod
+    public void stop() {
+        wireMockServer.stop();
+    }
+    
+    public FhirContext getFhirContext() {
+        return FHIR_CONTEXT;
+    }
+    
+    public IParser getFhirParser() {
+        return FHIR_PARSER;
+    }
+    
+    public int getHttpPort() {
+        if( HTTP_PORT == 0 ) {
+            try(ServerSocket socket = new ServerSocket(0)) {
+                HTTP_PORT = socket.getLocalPort();
+            } catch( Exception ex ) {
+                throw new RuntimeException("Failed to determine a port for the wiremock server", ex);
+            }
+        }
+        return HTTP_PORT;
+    }
+    
+    public IGenericClient newClient() {        
+        IGenericClient client = getFhirContext().newRestfulGenericClient(String.format("http://localhost:%d/", getHttpPort()));
+        
+        LoggingInterceptor logger = new LoggingInterceptor();
+        logger.setLogRequestSummary(true);
+        logger.setLogResponseBody(true);
+        client.registerInterceptor(logger);
+        
+        return client;
+    }
+    
+    public void mockNotFound(String resource) {
+        OperationOutcome outcome = new OperationOutcome();
+        outcome.getText().setStatusAsString("generated");
+        outcome.getIssueFirstRep().setSeverity(IssueSeverity.ERROR).setCode(OperationOutcome.IssueType.PROCESSING).setDiagnostics(resource);
+
+        mockFhirRead( resource, outcome, 404 );
+    }
+
+    public void mockFhirRead( Resource resource ) {
+        String resourcePath = "/" + resource.fhirType() + "/" + resource.getId();
+        mockFhirInteraction( resourcePath, resource );
+    }
+    
+    public void mockFhirRead( String path, Resource resource ) {
+        mockFhirRead( path, resource, 200 );
+    }
+
+    public void mockFhirRead( String path, Resource resource, int statusCode ) {
+        MappingBuilder builder = get(urlEqualTo(path));
+        mockFhirInteraction( builder, resource, statusCode );
+    }
+
+    public void mockFhirSearch( String path, Resource... resources ) {
+        MappingBuilder builder = get(urlEqualTo(path));
+        mockFhirInteraction( builder,  makeBundle( resources ) );
+    }
+    
+    public void mockFhirPost( String path, Resource resource ) {
+        mockFhirInteraction( post(urlEqualTo(path)), resource, 200 );
+    }
+
+    public void mockFhirInteraction( String path, Resource resource ) {
+        mockFhirRead( path, resource, 200 );
+    }
+
+    public void mockFhirInteraction( MappingBuilder builder, Resource resource ) {
+        mockFhirInteraction( builder, resource, 200 ); 
+    }
+
+    public void mockFhirInteraction( MappingBuilder builder, Resource resource, int statusCode ) {
+        String body = null;
+        if( resource != null ) {
+            body = getFhirParser().encodeResourceToString(resource);
+        }
+
+        stubFor(builder.willReturn(aResponse().withStatus(statusCode).withHeader("Content-Type", "application/json").withBody(body)));
+    }
+
+    public CapabilityStatement getCapabilityStatement() {
+        CapabilityStatement metadata = new CapabilityStatement();
+        metadata.setFhirVersion(Enumerations.FHIRVersion._4_0_1);
+        return metadata;
+    }
+
+    public Bundle makeBundle(List<? extends Resource> resources) {
+        return makeBundle( resources.toArray(new Resource[resources.size()]));
+    }
+
+    public Bundle makeBundle(Resource... resources) {        
+        Bundle bundle = new Bundle();
+        bundle.setType(Bundle.BundleType.SEARCHSET);
+        bundle.setTotal(resources != null ? resources.length : 0);
+        if( resources != null ) {
+            for (Resource l : resources) {
+                bundle.addEntry().setResource(l).setFullUrl("/" + l.getIdBase() + "/" + l.getId());
+            }
+        }
+        return bundle;
+    }
+}

--- a/engine.fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/terminology/TestR4FhirTerminologyProvider.java
+++ b/engine.fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/terminology/TestR4FhirTerminologyProvider.java
@@ -1,0 +1,204 @@
+package org.opencds.cqf.cql.engine.fhir.terminology;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import org.hl7.fhir.r4.model.BooleanType;
+import org.hl7.fhir.r4.model.Parameters;
+import org.hl7.fhir.r4.model.StringType;
+import org.hl7.fhir.r4.model.ValueSet;
+import org.opencds.cqf.cql.engine.fhir.R4FhirTest;
+import org.opencds.cqf.cql.engine.runtime.Code;
+import org.opencds.cqf.cql.engine.terminology.CodeSystemInfo;
+import org.opencds.cqf.cql.engine.terminology.ValueSetInfo;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+
+public class TestR4FhirTerminologyProvider extends R4FhirTest {
+
+	private static final String TEST_DISPLAY = "Display";
+	private static final String TEST_CODE = "425178004";
+	private static final String TEST_SYSTEM = "http://snomed.info/sct";
+	private static final String TEST_SYSTEM_VERSION = "2013-09";
+	R4FhirTerminologyProvider provider;
+	
+	@BeforeMethod
+	public void initializeProvider() {
+		provider = new R4FhirTerminologyProvider(newClient());
+	}
+	
+	@Test(expectedExceptions = UnsupportedOperationException.class)
+	public void nonNullVersionUnsupported() {
+		ValueSetInfo info = new ValueSetInfo();
+		info.setId("urn:oid:Test");
+		info.setVersion("1.0.0.");
+		
+		provider.resolveByUrl(info);
+	}
+	
+	@Test(expectedExceptions = UnsupportedOperationException.class)
+	public void nonNullCodesystemsUnsupported() {
+		CodeSystemInfo codeSystem = new CodeSystemInfo();
+		codeSystem.setId("SNOMED-CT");
+		codeSystem.setVersion("2013-09");
+		
+		ValueSetInfo info = new ValueSetInfo();
+		info.setId("urn:oid:Test");
+		info.getCodeSystems().add(codeSystem);
+		
+		provider.resolveByUrl(info);
+	}
+	
+	@Test
+	public void urnOidPrefixIsStripped() {
+		ValueSetInfo info = new ValueSetInfo();
+		info.setId("urn:oid:Test");
+		
+		provider.resolveByUrl(info);
+		assertEquals( info.getId(), "Test" );
+	}
+	
+	@Test( expectedExceptions = IllegalArgumentException.class )
+	public void moreThanOneURLSearchResultIsError() throws Exception {
+		ValueSetInfo info = new ValueSetInfo();
+		info.setId("http://localhost/fhir/ValueSet/1.2.3.4");
+		
+		ValueSet firstSet = new ValueSet();
+		firstSet.setId("1");
+		firstSet.setUrl(info.getId());
+		
+		ValueSet secondSet = new ValueSet();
+		secondSet.setId("1");
+		secondSet.setUrl(info.getId());
+		
+		mockFhirSearch("/ValueSet?url=" + urlencode(info.getId()) , firstSet, secondSet);
+		
+		provider.resolveByUrl(info);
+	}
+	
+	@Test( expectedExceptions = IllegalArgumentException.class )
+	public void zeroURLSearchResultIsError() throws Exception {
+		ValueSetInfo info = new ValueSetInfo();
+		info.setId("http://localhost/fhir/ValueSet/1.2.3.4");
+		
+		mockFhirSearch("/ValueSet?url=" + urlencode(info.getId()));
+		
+		provider.resolveByUrl(info);
+	}
+	
+	@Test
+	public void expandOperationReturnsCorrectCodesMoreThanZero() {
+		ValueSetInfo info = new ValueSetInfo();
+		info.setId("urn:oid:Test");
+		
+		ValueSet valueSet = new ValueSet();
+		valueSet.setId("Test");
+		valueSet.getExpansion().getContainsFirstRep().setSystem(TEST_SYSTEM).setCode(TEST_CODE);
+		
+		Parameters parameters = new Parameters();
+		parameters.getParameterFirstRep().setName("return").setResource(valueSet);
+		
+		mockFhirPost("/ValueSet/Test/$expand", parameters);
+		
+		Iterable<Code> codes = provider.expand(info);
+		
+		List<Code> list = StreamSupport.stream(codes.spliterator(), false).collect(Collectors.toList());
+		assertEquals( list.size(), 1 );
+		assertEquals( list.get(0).getSystem(), TEST_SYSTEM );
+		assertEquals( list.get(0).getCode(), TEST_CODE );
+	}
+	
+	@Test
+	public void inOperationReturnsTrueWhenFhirReturnsTrue() throws Exception {
+		ValueSetInfo info = new ValueSetInfo();
+		info.setId("urn:oid:Test");
+		
+		Code code = new Code();
+		code.setSystem(TEST_SYSTEM);
+		code.setCode(TEST_CODE);
+		code.setDisplay(TEST_DISPLAY);
+		
+		Parameters parameters = new Parameters();
+		parameters.getParameterFirstRep().setName("result").setValue(new BooleanType(true));
+		
+		mockFhirRead("/ValueSet/Test/$validate-code?code=" + urlencode(code.getCode()) + "&system=" + urlencode(code.getSystem()), parameters);
+		
+		boolean result = provider.in(code, info);
+		assertTrue( result );
+	}
+	
+	@Test
+	public void inOperationReturnsFalseWhenFhirReturnsFalse() throws Exception {
+		ValueSetInfo info = new ValueSetInfo();
+		info.setId("urn:oid:Test");
+		
+		Code code = new Code();
+		code.setSystem(TEST_SYSTEM);
+		code.setCode(TEST_CODE);
+		code.setDisplay(TEST_DISPLAY);
+		
+		Parameters parameters = new Parameters();
+		parameters.getParameterFirstRep().setName("result").setValue(new BooleanType(false));
+		
+		mockFhirRead("/ValueSet/Test/$validate-code?code=" + urlencode(code.getCode()) + "&system=" + urlencode(code.getSystem()), parameters);
+		
+		boolean result = provider.in(code, info);
+		assertFalse( result );
+	}
+	
+	@Test
+	public void inOperationHandlesNullSystem() throws Exception {
+		ValueSetInfo info = new ValueSetInfo();
+		info.setId("urn:oid:Test");
+		
+		Code code = new Code();
+		code.setCode(TEST_CODE);
+		code.setDisplay(TEST_DISPLAY);
+		
+		Parameters parameters = new Parameters();
+		parameters.getParameterFirstRep().setName("result").setValue(new BooleanType(true));
+		
+		mockFhirRead("/ValueSet/Test/$validate-code?code=" + urlencode(code.getCode()), parameters);
+		
+		boolean result = provider.in(code, info);
+		assertTrue( result );
+	}
+	
+	@Test
+	public void lookupOperationSuccess() throws Exception {
+		CodeSystemInfo info = new CodeSystemInfo();
+		info.setId(TEST_SYSTEM);
+		info.setVersion(TEST_SYSTEM_VERSION);
+		
+		Code code = new Code();
+		code.setCode(TEST_CODE);
+		code.setSystem(TEST_SYSTEM);
+		code.setDisplay(TEST_DISPLAY);
+		
+		Parameters parameters = new Parameters();
+		parameters.getParameterFirstRep().setName("name").setValue(new StringType(code.getCode()));
+		parameters.getParameterFirstRep().setName("version").setValue(new StringType(info.getVersion()));
+		parameters.getParameterFirstRep().setName("display").setValue(new StringType(code.getDisplay()));
+		
+		mockFhirPost("/CodeSystem/$lookup", parameters);
+		
+		Code result = provider.lookup(code, info);
+		assertNotNull( result );
+		assertEquals( result.getSystem(), code.getSystem() );
+		assertEquals( result.getCode(), code.getCode() );
+		assertEquals( result.getDisplay(), code.getDisplay() );
+	}
+	
+	protected String urlencode(String value) throws UnsupportedEncodingException {
+		return URLEncoder.encode(value, "utf-8");
+	}
+}

--- a/engine.fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/terminology/TestR4FhirTerminologyProvider.java
+++ b/engine.fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/terminology/TestR4FhirTerminologyProvider.java
@@ -185,9 +185,9 @@ public class TestR4FhirTerminologyProvider extends R4FhirTest {
 		code.setDisplay(TEST_DISPLAY);
 		
 		Parameters parameters = new Parameters();
-		parameters.getParameterFirstRep().setName("name").setValue(new StringType(code.getCode()));
-		parameters.getParameterFirstRep().setName("version").setValue(new StringType(info.getVersion()));
-		parameters.getParameterFirstRep().setName("display").setValue(new StringType(code.getDisplay()));
+		parameters.addParameter().setName("name").setValue(new StringType(code.getCode()));
+		parameters.addParameter().setName("version").setValue(new StringType(info.getVersion()));
+		parameters.addParameter().setName("display").setValue(new StringType(code.getDisplay()));
 		
 		mockFhirPost("/CodeSystem/$lookup", parameters);
 		

--- a/engine.fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/terminology/TestR4FhirTerminologyProvider.java
+++ b/engine.fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/terminology/TestR4FhirTerminologyProvider.java
@@ -1,7 +1,7 @@
 package org.opencds.cqf.cql.engine.fhir.terminology;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -25,180 +25,274 @@ import org.testng.annotations.Test;
 
 public class TestR4FhirTerminologyProvider extends R4FhirTest {
 
-	private static final String TEST_DISPLAY = "Display";
-	private static final String TEST_CODE = "425178004";
-	private static final String TEST_SYSTEM = "http://snomed.info/sct";
-	private static final String TEST_SYSTEM_VERSION = "2013-09";
-	R4FhirTerminologyProvider provider;
-	
-	@BeforeMethod
-	public void initializeProvider() {
-		provider = new R4FhirTerminologyProvider(newClient());
-	}
-	
-	@Test(expectedExceptions = UnsupportedOperationException.class)
-	public void nonNullVersionUnsupported() {
-		ValueSetInfo info = new ValueSetInfo();
-		info.setId("urn:oid:Test");
-		info.setVersion("1.0.0.");
-		
-		provider.resolveByUrl(info);
-	}
-	
-	@Test(expectedExceptions = UnsupportedOperationException.class)
-	public void nonNullCodesystemsUnsupported() {
-		CodeSystemInfo codeSystem = new CodeSystemInfo();
-		codeSystem.setId("SNOMED-CT");
-		codeSystem.setVersion("2013-09");
-		
-		ValueSetInfo info = new ValueSetInfo();
-		info.setId("urn:oid:Test");
-		info.getCodeSystems().add(codeSystem);
-		
-		provider.resolveByUrl(info);
-	}
-	
-	@Test
-	public void urnOidPrefixIsStripped() {
-		ValueSetInfo info = new ValueSetInfo();
-		info.setId("urn:oid:Test");
-		
-		provider.resolveByUrl(info);
-		assertEquals( info.getId(), "Test" );
-	}
-	
-	@Test( expectedExceptions = IllegalArgumentException.class )
-	public void moreThanOneURLSearchResultIsError() throws Exception {
-		ValueSetInfo info = new ValueSetInfo();
-		info.setId("http://localhost/fhir/ValueSet/1.2.3.4");
-		
-		ValueSet firstSet = new ValueSet();
-		firstSet.setId("1");
-		firstSet.setUrl(info.getId());
-		
-		ValueSet secondSet = new ValueSet();
-		secondSet.setId("1");
-		secondSet.setUrl(info.getId());
-		
-		mockFhirSearch("/ValueSet?url=" + urlencode(info.getId()) , firstSet, secondSet);
-		
-		provider.resolveByUrl(info);
-	}
-	
-	@Test( expectedExceptions = IllegalArgumentException.class )
-	public void zeroURLSearchResultIsError() throws Exception {
-		ValueSetInfo info = new ValueSetInfo();
-		info.setId("http://localhost/fhir/ValueSet/1.2.3.4");
-		
-		mockFhirSearch("/ValueSet?url=" + urlencode(info.getId()));
-		
-		provider.resolveByUrl(info);
-	}
-	
-	@Test
-	public void expandOperationReturnsCorrectCodesMoreThanZero() {
-		ValueSetInfo info = new ValueSetInfo();
-		info.setId("urn:oid:Test");
-		
-		ValueSet valueSet = new ValueSet();
-		valueSet.setId("Test");
-		valueSet.getExpansion().getContainsFirstRep().setSystem(TEST_SYSTEM).setCode(TEST_CODE);
-		
-		Parameters parameters = new Parameters();
-		parameters.getParameterFirstRep().setName("return").setResource(valueSet);
-		
-		mockFhirPost("/ValueSet/Test/$expand", parameters);
-		
-		Iterable<Code> codes = provider.expand(info);
-		
-		List<Code> list = StreamSupport.stream(codes.spliterator(), false).collect(Collectors.toList());
-		assertEquals( list.size(), 1 );
-		assertEquals( list.get(0).getSystem(), TEST_SYSTEM );
-		assertEquals( list.get(0).getCode(), TEST_CODE );
-	}
-	
-	@Test
-	public void inOperationReturnsTrueWhenFhirReturnsTrue() throws Exception {
-		ValueSetInfo info = new ValueSetInfo();
-		info.setId("urn:oid:Test");
-		
-		Code code = new Code();
-		code.setSystem(TEST_SYSTEM);
-		code.setCode(TEST_CODE);
-		code.setDisplay(TEST_DISPLAY);
-		
-		Parameters parameters = new Parameters();
-		parameters.getParameterFirstRep().setName("result").setValue(new BooleanType(true));
-		
-		mockFhirRead("/ValueSet/Test/$validate-code?code=" + urlencode(code.getCode()) + "&system=" + urlencode(code.getSystem()), parameters);
-		
-		boolean result = provider.in(code, info);
-		assertTrue( result );
-	}
-	
-	@Test
-	public void inOperationReturnsFalseWhenFhirReturnsFalse() throws Exception {
-		ValueSetInfo info = new ValueSetInfo();
-		info.setId("urn:oid:Test");
-		
-		Code code = new Code();
-		code.setSystem(TEST_SYSTEM);
-		code.setCode(TEST_CODE);
-		code.setDisplay(TEST_DISPLAY);
-		
-		Parameters parameters = new Parameters();
-		parameters.getParameterFirstRep().setName("result").setValue(new BooleanType(false));
-		
-		mockFhirRead("/ValueSet/Test/$validate-code?code=" + urlencode(code.getCode()) + "&system=" + urlencode(code.getSystem()), parameters);
-		
-		boolean result = provider.in(code, info);
-		assertFalse( result );
-	}
-	
-	@Test
-	public void inOperationHandlesNullSystem() throws Exception {
-		ValueSetInfo info = new ValueSetInfo();
-		info.setId("urn:oid:Test");
-		
-		Code code = new Code();
-		code.setCode(TEST_CODE);
-		code.setDisplay(TEST_DISPLAY);
-		
-		Parameters parameters = new Parameters();
-		parameters.getParameterFirstRep().setName("result").setValue(new BooleanType(true));
-		
-		mockFhirRead("/ValueSet/Test/$validate-code?code=" + urlencode(code.getCode()), parameters);
-		
-		boolean result = provider.in(code, info);
-		assertTrue( result );
-	}
-	
-	@Test
-	public void lookupOperationSuccess() throws Exception {
-		CodeSystemInfo info = new CodeSystemInfo();
-		info.setId(TEST_SYSTEM);
-		info.setVersion(TEST_SYSTEM_VERSION);
-		
-		Code code = new Code();
-		code.setCode(TEST_CODE);
-		code.setSystem(TEST_SYSTEM);
-		code.setDisplay(TEST_DISPLAY);
-		
-		Parameters parameters = new Parameters();
-		parameters.addParameter().setName("name").setValue(new StringType(code.getCode()));
-		parameters.addParameter().setName("version").setValue(new StringType(info.getVersion()));
-		parameters.addParameter().setName("display").setValue(new StringType(code.getDisplay()));
-		
-		mockFhirPost("/CodeSystem/$lookup", parameters);
-		
-		Code result = provider.lookup(code, info);
-		assertNotNull( result );
-		assertEquals( result.getSystem(), code.getSystem() );
-		assertEquals( result.getCode(), code.getCode() );
-		assertEquals( result.getDisplay(), code.getDisplay() );
-	}
-	
-	protected String urlencode(String value) throws UnsupportedEncodingException {
-		return URLEncoder.encode(value, "utf-8");
-	}
+    private static final String TEST_DISPLAY = "Display";
+    private static final String TEST_CODE = "425178004";
+    private static final String TEST_SYSTEM = "http://snomed.info/sct";
+    private static final String TEST_SYSTEM_VERSION = "2013-09";
+    R4FhirTerminologyProvider provider;
+    
+    @BeforeMethod
+    public void initializeProvider() {
+        provider = new R4FhirTerminologyProvider(newClient());
+    }
+    
+    @Test
+    public void resolveByUrlUsingUrlSucceeds() throws Exception {
+        ValueSetInfo info = new ValueSetInfo().withId("https://cts.nlm.nih.gov/fhir/ValueSet/1.2.3.4");
+        
+        ValueSet response = new ValueSet();
+        response.setId("1.2.3.4");
+        response.setUrl(info.getId());
+        
+        mockResolveSearchPath(info, response);
+        
+        assertEquals(Boolean.TRUE, provider.resolveByUrl(info));
+    }
+    
+    @Test
+    public void resolveByUrlUsingIdentifierSucceeds() throws Exception {
+        ValueSetInfo info = new ValueSetInfo().withId("urn:oid:1.2.3.4");
+        
+        ValueSet response = new ValueSet();
+        response.setId("1.2.3.4");
+        response.addIdentifier().setValue(info.getId());
+        
+        mockResolveSearchPath(info, response);
+        
+        assertEquals(provider.resolveByUrl(info), Boolean.TRUE);
+    }
+    
+    @Test
+    public void resolveByUrlUsingResourceIdSucceeds() throws Exception {
+        ValueSetInfo info = new ValueSetInfo().withId("urn:oid:1.2.3.4");
+        
+        ValueSet response = new ValueSet();
+        response.setId("1.2.3.4");
+        
+        mockResolveSearchPath(info, response);
+        
+        assertEquals(provider.resolveByUrl(info), Boolean.TRUE);
+    }
+    
+    @Test(expectedExceptions=IllegalArgumentException.class)
+    public void resolveByUrlNoMatchesThrowsException() throws Exception {
+        ValueSetInfo info = new ValueSetInfo().withId("urn:oid:1.2.3.4");
+        
+        mockResolveSearchPath(info, null);
+        
+        provider.resolveByUrl(info);
+    }    
+    
+    @Test(expectedExceptions = UnsupportedOperationException.class)
+    public void nonNullVersionUnsupported() {
+        ValueSetInfo info = new ValueSetInfo();
+        info.setId("urn:oid:Test");
+        info.setVersion("1.0.0.");
+        
+        provider.resolveByUrl(info);
+    }
+    
+    @Test(expectedExceptions = UnsupportedOperationException.class)
+    public void nonNullCodesystemsUnsupported() {
+        CodeSystemInfo codeSystem = new CodeSystemInfo();
+        codeSystem.setId("SNOMED-CT");
+        codeSystem.setVersion("2013-09");
+        
+        ValueSetInfo info = new ValueSetInfo();
+        info.setId("urn:oid:Test");
+        info.getCodeSystems().add(codeSystem);
+        
+        provider.resolveByUrl(info);
+    }
+    
+    @Test
+    public void urnOidPrefixIsStripped() throws Exception {
+        ValueSetInfo info = new ValueSetInfo();
+        info.setId("urn:oid:Test");
+        
+        ValueSet valueSet = new ValueSet();
+        valueSet.setId("Test");
+        valueSet.getExpansion().getContainsFirstRep().setSystem(TEST_SYSTEM).setCode(TEST_CODE);
+        
+        mockResolveSearchPath(info, valueSet);
+        
+        provider.resolveByUrl(info);
+        assertEquals( info.getId(), "Test" );
+    }
+    
+    @Test( expectedExceptions = IllegalArgumentException.class )
+    public void moreThanOneURLSearchResultIsError() throws Exception {
+        ValueSetInfo info = new ValueSetInfo();
+        info.setId("http://localhost/fhir/ValueSet/1.2.3.4");
+        
+        ValueSet firstSet = new ValueSet();
+        firstSet.setId("1");
+        firstSet.setUrl(info.getId());
+        
+        ValueSet secondSet = new ValueSet();
+        secondSet.setId("1");
+        secondSet.setUrl(info.getId());
+        
+        mockFhirSearch("/ValueSet?url=" + urlencode(info.getId()) , firstSet, secondSet);
+        
+        provider.resolveByUrl(info);
+    }
+    
+    @Test( expectedExceptions = IllegalArgumentException.class )
+    public void zeroURLSearchResultIsError() throws Exception {
+        ValueSetInfo info = new ValueSetInfo();
+        info.setId("http://localhost/fhir/ValueSet/1.2.3.4");
+        
+        mockResolveSearchPath(info, null);
+        
+        provider.resolveByUrl(info);
+    }
+    
+    @Test
+    public void expandOperationReturnsCorrectCodesMoreThanZero() throws Exception {
+        ValueSetInfo info = new ValueSetInfo();
+        info.setId("urn:oid:Test");
+        
+        ValueSet valueSet = new ValueSet();
+        valueSet.setId("Test");
+        valueSet.getExpansion().getContainsFirstRep().setSystem(TEST_SYSTEM).setCode(TEST_CODE);
+        
+        mockResolveSearchPath(info, valueSet);
+
+        Parameters parameters = new Parameters();
+        parameters.getParameterFirstRep().setName("return").setResource(valueSet);
+        
+        mockFhirRead("/ValueSet/Test/$expand", parameters);
+        
+        Iterable<Code> codes = provider.expand(info);
+        
+        List<Code> list = StreamSupport.stream(codes.spliterator(), false).collect(Collectors.toList());
+        assertEquals( list.size(), 1 );
+        assertEquals( list.get(0).getSystem(), TEST_SYSTEM );
+        assertEquals( list.get(0).getCode(), TEST_CODE );
+    }
+    
+    @Test
+    public void inOperationReturnsTrueWhenFhirReturnsTrue() throws Exception {
+        ValueSetInfo info = new ValueSetInfo();
+        info.setId("urn:oid:Test");
+        
+        ValueSet valueSet = new ValueSet();
+        valueSet.setId("Test");
+        valueSet.getExpansion().getContainsFirstRep().setSystem(TEST_SYSTEM).setCode(TEST_CODE);
+        
+        mockResolveSearchPath(info, valueSet);
+        
+        Code code = new Code();
+        code.setSystem(TEST_SYSTEM);
+        code.setCode(TEST_CODE);
+        code.setDisplay(TEST_DISPLAY);
+        
+        Parameters parameters = new Parameters();
+        parameters.getParameterFirstRep().setName("result").setValue(new BooleanType(true));
+        
+        mockFhirRead("/ValueSet/Test/$validate-code?code=" + urlencode(code.getCode()) + "&system=" + urlencode(code.getSystem()), parameters);
+        
+        boolean result = provider.in(code, info);
+        assertTrue( result );
+    }
+    
+    @Test
+    public void inOperationReturnsFalseWhenFhirReturnsFalse() throws Exception {
+        ValueSetInfo info = new ValueSetInfo();
+        info.setId("urn:oid:Test");
+        
+        ValueSet valueSet = new ValueSet();
+        valueSet.setId("Test");
+        
+        mockResolveSearchPath(info, valueSet);
+        
+        Code code = new Code();
+        code.setSystem(TEST_SYSTEM);
+        code.setCode(TEST_CODE);
+        code.setDisplay(TEST_DISPLAY);
+        
+        Parameters parameters = new Parameters();
+        parameters.getParameterFirstRep().setName("result").setValue(new BooleanType(false));
+        
+        mockFhirRead("/ValueSet/Test/$validate-code?code=" + urlencode(code.getCode()) + "&system=" + urlencode(code.getSystem()), parameters);
+        
+        boolean result = provider.in(code, info);
+        assertFalse( result );
+    }
+    
+    @Test
+    public void inOperationHandlesNullSystem() throws Exception {
+        ValueSetInfo info = new ValueSetInfo();
+        info.setId("urn:oid:Test");
+        
+        ValueSet valueSet = new ValueSet();
+        valueSet.setId("Test");
+        
+        mockResolveSearchPath(info, valueSet);
+        
+        Code code = new Code();
+        code.setCode(TEST_CODE);
+        code.setDisplay(TEST_DISPLAY);
+        
+        Parameters parameters = new Parameters();
+        parameters.getParameterFirstRep().setName("result").setValue(new BooleanType(true));
+        
+        mockFhirRead("/ValueSet/Test/$validate-code?code=" + urlencode(code.getCode()), parameters);
+        
+        boolean result = provider.in(code, info);
+        assertTrue( result );
+    }
+    
+    @Test
+    public void lookupOperationSuccess() throws Exception {
+        CodeSystemInfo info = new CodeSystemInfo();
+        info.setId(TEST_SYSTEM);
+        info.setVersion(TEST_SYSTEM_VERSION);
+        
+        Code code = new Code();
+        code.setCode(TEST_CODE);
+        code.setSystem(TEST_SYSTEM);
+        code.setDisplay(TEST_DISPLAY);
+        
+        Parameters parameters = new Parameters();
+        parameters.addParameter().setName("name").setValue(new StringType(code.getCode()));
+        parameters.addParameter().setName("version").setValue(new StringType(info.getVersion()));
+        parameters.addParameter().setName("display").setValue(new StringType(code.getDisplay()));
+        
+        mockFhirPost("/CodeSystem/$lookup", parameters);
+        
+        Code result = provider.lookup(code, info);
+        assertNotNull( result );
+        assertEquals( result.getSystem(), code.getSystem() );
+        assertEquals( result.getCode(), code.getCode() );
+        assertEquals( result.getDisplay(), code.getDisplay() );
+    }
+    
+    protected String urlencode(String value) throws UnsupportedEncodingException {
+        return URLEncoder.encode(value, "utf-8");
+    }
+    
+    protected void mockResolveSearchPath(ValueSetInfo info, ValueSet valueSet) throws UnsupportedEncodingException {
+        if( valueSet != null && valueSet.getUrl() != null ) {
+            mockFhirSearch("/ValueSet?url=" + urlencode(info.getId()), valueSet);
+        } else { 
+            mockFhirSearch("/ValueSet?url=" + urlencode(info.getId()));
+        }
+        
+        if( valueSet != null && valueSet.getIdentifier().size() > 0 ) {
+            mockFhirSearch("/ValueSet?identifier=" + urlencode(info.getId()), valueSet);
+        } else {
+            mockFhirSearch("/ValueSet?identifier=" + urlencode(info.getId()));
+        }
+        
+        
+        if( valueSet != null ) {
+            mockFhirRead("/ValueSet/" + valueSet.getId(), valueSet);
+        } else { 
+            String [] parts = info.getId().split("[:/]");
+            String expectedId = parts[parts.length - 1];
+            mockNotFound("/ValueSet/" + expectedId);
+        }
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -250,6 +250,12 @@
                 <version>1.7.29</version>
                 <scope>test</scope>
             </dependency>
+            <dependency>
+                <groupId>com.github.tomakehurst</groupId>
+                <artifactId>wiremock-jre8</artifactId>
+                <version>2.27.2</version>
+                <scope>test</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
This changeset resolves cqframework/clinical_quality_language#929, cqframework/clinical_quality_language#921, cqframework/clinical_quality_language#920, and cqframework/clinical_quality_language#919 by introducing logic
to:

1) Strip the urn:oid prefix from ValueSetInfo.id if it is there.
2) Throw an UnsupportedOperationException if the CQL library tries to
use ValueSetInfo.version or ValueSetInfo.codeSystems.
3) Throw an IllegalArgumentException if the result of a URL-based query
returns an unexpected number of results (0 or >1)

Additionally, I updated the lookup operation to use named parameters vs.
positional indexes when dealing with the operation response which seemed
like a more reliable pattern.

As much as was reasonable I tried to mirror the logic in
hapi-fhir-jpaserver-cql/src/main/java/ca/uhn/fhir/cql/r4/provider/JpaTerminologyProvider.java.

I added a test dependency on wiremock and I use it to mock FHIR
interactions for test purposes.