### PR TITLE
#463 - Add ability to configure search page size

### DIFF
--- a/engine.fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/retrieve/RestFhirRetrieveProvider.java
+++ b/engine.fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/retrieve/RestFhirRetrieveProvider.java
@@ -121,6 +121,10 @@ public class RestFhirRetrieveProvider extends SearchParamFhirRetrieveProvider {
 
 				flattenedMap.put(name, flattened);
 			}
+			
+			if (getPageSize() != null) {
+			    search.count(getPageSize());
+			}
 
 			return search.where(flattenedMap).usingStyle(this.searchStyle).execute();
 		}

--- a/engine.fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/retrieve/SearchParamFhirRetrieveProvider.java
+++ b/engine.fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/retrieve/SearchParamFhirRetrieveProvider.java
@@ -29,11 +29,24 @@ public abstract class SearchParamFhirRetrieveProvider extends TerminologyAwareRe
     private static final int DEFAULT_MAX_CODES_PER_QUERY = 64;
 
     private SearchParameterResolver searchParameterResolver;
+    private Integer pageSize;
     private int maxCodesPerQuery;
 
     public SearchParamFhirRetrieveProvider(SearchParameterResolver searchParameterResolver) {
         this.searchParameterResolver = searchParameterResolver;
         this.maxCodesPerQuery = DEFAULT_MAX_CODES_PER_QUERY;
+    }
+    
+    public void setPageSize(Integer value) {
+        if( value == null || value < 1 ) { 
+            throw new IllegalArgumentException("value must be a non-null integer > 0");
+        }
+        
+        this.pageSize = value;
+    }
+    
+    public Integer getPageSize() {
+        return this.pageSize;
     }
 
     public void setMaxCodesPerQuery(int value) {
@@ -244,6 +257,10 @@ public abstract class SearchParamFhirRetrieveProvider extends TerminologyAwareRe
 
         SearchParameterMap baseMap = new SearchParameterMap();
         baseMap.setLastUpdated(new DateRangeParam());
+        
+        if (this.pageSize != null) {
+            baseMap.setCount(this.pageSize);
+        }
 
         if (templateParam != null) {
             baseMap.add(templateParam.getKey(), templateParam.getValue());

--- a/engine.fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/retrieve/TestRestFhirRetrieveProvider.java
+++ b/engine.fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/retrieve/TestRestFhirRetrieveProvider.java
@@ -1,0 +1,120 @@
+package org.opencds.cqf.cql.engine.fhir.retrieve;
+
+import static ca.uhn.fhir.util.UrlUtil.escapeUrlParam;
+import static org.testng.Assert.assertEquals;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Arrays;
+import java.util.List;
+
+import org.hl7.fhir.r4.model.Patient;
+import org.opencds.cqf.cql.engine.fhir.R4FhirTest;
+import org.opencds.cqf.cql.engine.fhir.searchparam.SearchParameterMap;
+import org.opencds.cqf.cql.engine.fhir.searchparam.SearchParameterResolver;
+import org.opencds.cqf.cql.engine.runtime.Code;
+import org.opencds.cqf.cql.engine.runtime.DateTime;
+import org.opencds.cqf.cql.engine.runtime.Interval;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Ignore;
+import org.testng.annotations.Test;
+
+import ca.uhn.fhir.rest.client.api.IGenericClient;
+
+public class TestRestFhirRetrieveProvider extends R4FhirTest {
+    
+    static SearchParameterResolver RESOLVER;
+    static IGenericClient CLIENT;
+    
+    RestFhirRetrieveProvider provider;
+    
+    @BeforeClass
+    public void setUpBeforeClass() {
+        CLIENT= newClient();
+        RESOLVER = new SearchParameterResolver(CLIENT.getFhirContext());
+    }
+    
+    @BeforeMethod
+    public void setUp() {
+        this.provider = new RestFhirRetrieveProvider(RESOLVER, CLIENT);
+    }
+    
+    
+    @Test
+    public void noUserSpecifiedPageSizeUsesDefault() {
+        SearchParameterMap map = provider.getBaseMap(null, null, null);
+        assertEquals( map.getCount(), null );
+    }
+    
+    @Test
+    public void userSpecifiedPageSizeIsUsed() {
+        Integer expected = 100;
+        provider.setPageSize(expected);
+        SearchParameterMap map = provider.getBaseMap(null, null, null);
+        assertEquals( map.getCount(), expected );
+    }
+    
+    @Test
+    public void userSpecifiedPageSizeIsUsedWhenCodeBasedQuery() {
+        Code code = new Code().withSystem("http://mysystem.com").withCode("mycode");
+        List<Code> codes = Arrays.asList( code );
+        
+        mockFhirSearch("/Condition?code=" + escapeUrlParam(code.getSystem() + "|" + code.getCode()) + "&subject=" + escapeUrlParam("Patient/123") + "&_count=500");
+        
+        provider.setPageSize(500);
+        provider.retrieve("Patient", "subject", "123", "Condition", null, "code", codes, null, null, null, null, null);
+    }
+    
+    @Test
+    public void userSpecifiedPageSizeIsUsedWhenValueSetQuery() {
+       
+        String valueSetUrl = "http://myterm.com/fhir/ValueSet/MyValueSet";
+        
+        // TODO - This should generate an :in query, but is currently broken (See #466).
+        // I am mocking the way it works today specifically for the page size
+        // feature, but this test will need to be updated when the :in behavior
+        // starts working.
+        mockFhirSearch("/Condition?code=" + escapeUrlParam(valueSetUrl) + "&subject=" + escapeUrlParam("Patient/123") + "&_count=500");
+        
+        provider.setPageSize(500);
+        provider.retrieve("Patient", "subject", "123", "Condition", "http://hl7.org/fhir/StructureDefinition/Condition", "code", null, valueSetUrl, null, null, null, null);
+    }
+    
+    @Test
+    @Ignore
+    public void userSpecifiedPageSizeIsUsedWhenDateQuery() {
+       /**
+        * As best as I can tell, the date range optimized queries are
+        * broken right now. See https://github.com/DBCG/cql_engine/issues/467.
+        */
+        
+        OffsetDateTime start = OffsetDateTime.of(2020, 11, 12, 1, 2, 3, 0, ZoneOffset.UTC);
+        OffsetDateTime end = start.plusYears(1);
+        
+        Interval interval = new Interval(new DateTime(start), true, new DateTime(end), false);
+        
+        mockFhirSearch("/Condition?subject=" + escapeUrlParam("Patient/123") + "&_count=500");
+        
+        provider.setPageSize(500);
+        provider.retrieve("Patient", "subject", "123", "Condition", null, "code", null, null, "onset-date", null, null, interval);
+    } 
+    
+    @Test
+    public void userSpecifiedPageSizeNotUsedWhenIDQuery() {
+        mockFhirRead("/Patient/123", new Patient());
+        
+        provider.setPageSize(500);
+        provider.retrieve("Patient", "id", "123", "Patient", "http://hl7.org/fhir/StructureDefinition/Patient", null, null, null, null, null, null, null);
+    }
+    
+    @Test
+    public void noUserSpecifiedPageSizeSpecifiedNoCountInURL() {
+        Code code = new Code().withSystem("http://mysystem.com").withCode("mycode");
+        List<Code> codes = Arrays.asList( code );
+        
+        mockFhirSearch("/Condition?code=" + escapeUrlParam(code.getSystem() + "|" + code.getCode()) + "&subject=" + escapeUrlParam("Patient/123"));
+        
+        provider.retrieve("Patient", "subject", "123", "Condition", null, "code", codes, null, null, null, null, null);
+    }
+}


### PR DESCRIPTION
This PR resolves cqframework/clinical_quality_language#918 by adding a pageSize property to the RestFhirRetrieveProvider. This value will be sent as the _count parameter in search queries. The default _count value for FHIR servers can be quite low (10-20 records at a time) resulting in a large number of REST calls to the server when retrieving data necessary for CQL evaluation. This parameter enables the user to configure how many rows should be returned per request to the server and potentially giving them the ability to boost performance.

While testing, I noted some broken/unexpected behavior as described in cqframework/clinical_quality_language#917 and cqframework/clinical_quality_language#916. I left tests in place that test those behaviors, but they are ignored or coded to pass right now. Those tests will need to be revisited as fixes come in.