### PR TITLE
#469 Fix broken SLF4J logging in tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
         <jackson.version>2.12.3</jackson.version>
         <cqframework.version>1.5.3</cqframework.version>
         <hapi.version>5.3.2</hapi.version>
+        <slf4j.version>1.7.29</slf4j.version>
     </properties>
 
     <repositories>
@@ -242,8 +243,18 @@
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>${slf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>jcl-over-slf4j</artifactId>
+                <version>${slf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-simple</artifactId>
-                <version>2.0.0-alpha1</version>
+                <version>${slf4j.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>

--- a/scripts/maintenance.sh
+++ b/scripts/maintenance.sh
@@ -4,4 +4,4 @@
 set -euxo pipefail
 bash -n "$0"
 
-mvn versions:update-properties versions:use-releases versions:use-latest-releases -Dexcludes=org.jvnet.jaxb2_commons:jaxb2-basics:jar:0.12.0,org.eclipse.persistence:org.eclipse.persistence.moxy:jar:2.7.7
+mvn versions:update-properties versions:use-releases versions:use-latest-releases -Dexcludes=org.jvnet.jaxb2_commons:jaxb2-basics:jar:0.12.0,org.eclipse.persistence:org.eclipse.persistence.moxy:jar:2.7.7,org.slf4j:\*


### PR DESCRIPTION
The slf4j-simple dependency got auto-upgraded as part of the maintenance
script execution. This created a problem where the API and log bindings
were on different versions and the log binding was not getting loaded
properly. I updated the POM to explicitly declare the API and log
binding versions and use a property to make sure they are in sync. I
also excluded these from getting automatically upgraded to the 2.x alpha
line of releases next time the maintenance script runs.