### PR TITLE
#467 - address an issue with some date parameters not resolving

### DIFF
--- a/engine.fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/retrieve/SearchParamFhirRetrieveProvider.java
+++ b/engine.fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/retrieve/SearchParamFhirRetrieveProvider.java
@@ -114,7 +114,7 @@ public abstract class SearchParamFhirRetrieveProvider extends TerminologyAwareRe
         RuntimeSearchParam dateParam = this.searchParameterResolver.getSearchParameterDefinition(dataType, datePath, RestSearchParameterTypeEnum.DATE);
 
         if (dateParam == null) {
-            return null;
+            throw new UnsupportedOperationException(String.format("Could not resolve a search parameter with date type for %s.%s ", dataType, datePath));
         }
 
         return Pair.of(dateParam.getName(), rangeParam);

--- a/engine.fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/searchparam/TestSearchParameterResolver.java
+++ b/engine.fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/searchparam/TestSearchParameterResolver.java
@@ -125,6 +125,22 @@ public class TestSearchParameterResolver {
                 RestSearchParameterTypeEnum.DATE);
         assertNotNull(param);
         assertEquals("authored", param.getName());
+        
+        param = resolver.getSearchParameterDefinition("Condition", "onset", RestSearchParameterTypeEnum.DATE);
+        assertNotNull(param);
+        assertEquals("onset-date", param.getName());
+        
+        param = resolver.getSearchParameterDefinition("Condition", "abatement", RestSearchParameterTypeEnum.DATE);
+        assertNotNull(param);
+        assertEquals("abatement-date", param.getName());
+        
+        param = resolver.getSearchParameterDefinition("Observation", "effective", RestSearchParameterTypeEnum.DATE);
+        assertNotNull(param);
+        assertEquals("date", param.getName());
+        
+        param = resolver.getSearchParameterDefinition("Observation", "value", RestSearchParameterTypeEnum.DATE);
+        assertNotNull(param);
+        assertEquals("value-date", param.getName());
     }
 
     @Test


### PR DESCRIPTION
There are two changes here related to cqframework/clinical_quality_language#916.

1) The SearchParameterResolver.normalizePath method was updated to better handle search parameters that are unions of different conditions. This was specifically relevant for ``/Condition?onset-date`` and ``/Condition?abatement-date`` which are represented by ``Condition.onset.as(dateTime) | Condition.onset.as(Period)`` and ``Condition.abatement.as(dateTime) | Condition.abatement.as(Period)`` in the FHIR specification.  The new logic will split the string on the pipe character and then normalize each part of the union separately. If all parts refer to the same property path (e.g. onset or abatement), then that value is returned. If not, null is returned. This enables date range optimized queries to work for fields expressed in this manner.

2) Previously, if a search parameter could not be resolved for the dateRange query parameter, this error would be passed over and the CQL engine would just load all data regardless of date range requested. I changed the retrieve provider to throw an exception if a date range query was attempted, but no parameter could be resolved.

These changes do not provide a complete fix for the problem of not being able to resolve search parameters for specific fields, but they do improve the state of the art.