### PR TITLE
Add profile for Java 8 vs 9 builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -330,7 +330,6 @@
                     <configuration>
                         <source>1.8</source>
                         <target>1.8</target>
-                        <release>8</release>
                         <failOnError>true</failOnError>
                         <failOnWarning>true</failOnWarning>
                         <compilerArgs>
@@ -538,6 +537,25 @@
                         <artifactId>nexus-staging-maven-plugin</artifactId>
                     </plugin>
                 </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>java-9</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-compiler-plugin</artifactId>
+                            <configuration>
+                                <release>8</release>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
             </build>
         </profile>
     </profiles>


### PR DESCRIPTION
* Add a maven profile so that the "release" compile option is only activated on Java 9+
* Resolves cqframework/clinical_quality_language#933 

Future effort needs to set up CI to build under both environments.