### PR TITLE
Update to HAPI 5.4

### DIFF
--- a/engine.fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/model/Dstu2FhirModelResolver.java
+++ b/engine.fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/model/Dstu2FhirModelResolver.java
@@ -34,6 +34,8 @@ import org.opencds.cqf.cql.engine.runtime.BaseTemporal;
 public class Dstu2FhirModelResolver extends  FhirModelResolver<Base, BaseDateTimeType, TimeType, SimpleQuantity, IdType, Resource, Enumeration<?>, EnumFactory<?>> {
 
 	public Dstu2FhirModelResolver() {
+        // This ModelResolver makes specific alterations to the FhirContext,
+        // so it's unable to use a cached version.
 		this(FhirContext.forDstu2());
 	}
 
@@ -41,7 +43,7 @@ public class Dstu2FhirModelResolver extends  FhirModelResolver<Base, BaseDateTim
         super(fhirContext);
 
         this.setPackageName("org.hl7.fhir.dstu2.model");
-        
+
         if (fhirContext.getVersion().getVersion() != FhirVersionEnum.DSTU2) {
             throw new IllegalArgumentException("The supplied context is not configured for DSTU2");
         }
@@ -66,7 +68,7 @@ public class Dstu2FhirModelResolver extends  FhirModelResolver<Base, BaseDateTim
             this.fhirContext.getResourceDefinition(type.toCode());
         }
     }
-    
+
     protected Boolean equalsDeep(Base left, Base right) {
         return left.equalsDeep(right);
     }

--- a/engine.fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/model/Dstu3FhirModelResolver.java
+++ b/engine.fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/model/Dstu3FhirModelResolver.java
@@ -34,6 +34,8 @@ public class Dstu3FhirModelResolver extends
         FhirModelResolver<Base, BaseDateTimeType, TimeType, SimpleQuantity, IdType, Resource, Enumeration<?>, EnumFactory<?>> {
 
     public Dstu3FhirModelResolver() {
+        // This ModelResolver makes specific alterations to the FhirContext,
+        // so it's unable to use a cached version.
         this(FhirContext.forDstu3());
     }
 

--- a/engine.fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/model/R4FhirModelResolver.java
+++ b/engine.fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/model/R4FhirModelResolver.java
@@ -34,6 +34,8 @@ import org.opencds.cqf.cql.engine.runtime.BaseTemporal;
 public class R4FhirModelResolver extends FhirModelResolver<Base, BaseDateTimeType, TimeType, SimpleQuantity, IdType, Resource, Enumeration<?>, EnumFactory<?>> {
 
 	public R4FhirModelResolver() {
+        // This ModelResolver makes specific alterations to the FhirContext,
+        // so it's unable to use a cached version.
         this(FhirContext.forR4());
 	}
 
@@ -44,7 +46,7 @@ public class R4FhirModelResolver extends FhirModelResolver<Base, BaseDateTimeTyp
             throw new IllegalArgumentException("The supplied context is not configured for R4");
         }
     }
-    
+
     protected void initialize() {
         // HAPI has some bugs where it's missing annotations on certain types. This patches that.
         this.fhirContext.registerCustomType(AnnotatedUuidType.class);
@@ -75,7 +77,7 @@ public class R4FhirModelResolver extends FhirModelResolver<Base, BaseDateTimeTyp
 
         return super.resolveProperty(target, path);
     }
-    
+
     protected Boolean equalsDeep(Base left, Base right) {
         return left.equalsDeep(right);
     }

--- a/engine.fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/searchparam/SearchParameterResolver.java
+++ b/engine.fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/searchparam/SearchParameterResolver.java
@@ -8,6 +8,7 @@ import java.util.Set;
 import org.apache.commons.lang3.tuple.Pair;
 
 import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.context.FhirVersionEnum;
 import ca.uhn.fhir.context.RuntimeSearchParam;
 import ca.uhn.fhir.model.api.IQueryParameterType;
 import ca.uhn.fhir.rest.api.RestSearchParameterTypeEnum;
@@ -55,7 +56,7 @@ public class SearchParameterResolver {
             // Filter out parameters that don't match our requested type.
             if (paramType != null && !param.getParamType().equals(paramType)) {
                 continue;
-            } 
+            }
 
             String normalizedPath = normalizePath(param.getPath());
             if (path.equals(normalizedPath) ) {
@@ -85,7 +86,7 @@ public class SearchParameterResolver {
                 return Pair.of(name, new QuantityParam(value));
             case STRING:
                 return Pair.of(name, new StringParam(value));
-            case NUMBER: 
+            case NUMBER:
                 return Pair.of(name, new NumberParam(value));
             case URI:
                 return Pair.of(name, new UriParam(value));

--- a/engine.fhir/src/test/java/org/hl7/fhirpath/TestFhirPath.java
+++ b/engine.fhir/src/test/java/org/hl7/fhirpath/TestFhirPath.java
@@ -54,17 +54,18 @@ import org.opencds.cqf.cql.engine.runtime.Time;
 import org.testng.annotations.Test;
 
 import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.context.FhirVersionEnum;
 
 public class TestFhirPath {
 
-    private FhirContext fhirContext = FhirContext.forDstu3();
+    private FhirContext fhirContext = FhirContext.forCached(FhirVersionEnum.DSTU3);
     private Dstu3FhirModelResolver dstu3ModelResolver = new Dstu3FhirModelResolver();
     private RestFhirRetrieveProvider dstu3RetrieveProvider = new RestFhirRetrieveProvider(new SearchParameterResolver(fhirContext),
             fhirContext.newRestfulGenericClient("http://fhirtest.uhn.ca/baseDstu3"));
     private CompositeDataProvider provider = new CompositeDataProvider(dstu3ModelResolver, dstu3RetrieveProvider);
 
 
-    private FhirContext fhirContextR4 = FhirContext.forR4();
+    private FhirContext fhirContextR4 = FhirContext.forCached(FhirVersionEnum.R4);
     private R4FhirModelResolver r4FhirModelResolver = new R4FhirModelResolver();
     private RestFhirRetrieveProvider r4RetrieveProvider = new RestFhirRetrieveProvider(new SearchParameterResolver(fhirContextR4),
             fhirContextR4.newRestfulGenericClient("http://fhirtest.uhn.ca/baseR4"));
@@ -495,7 +496,7 @@ public class TestFhirPath {
         context.registerLibraryLoader(getLibraryLoader());
 
         Dstu3FhirModelResolver modelResolver = new Dstu3FhirModelResolver();
-        FhirContext fhirContext = FhirContext.forDstu3();
+        FhirContext fhirContext = FhirContext.forCached(FhirVersionEnum.DSTU3);
         RestFhirRetrieveProvider retrieveProvider = new RestFhirRetrieveProvider(new SearchParameterResolver(fhirContext),
                 fhirContext.newRestfulGenericClient("http://fhirtest.uhn.ca/baseDstu3"));
         CompositeDataProvider provider = new CompositeDataProvider(modelResolver, retrieveProvider);
@@ -532,7 +533,7 @@ public class TestFhirPath {
         Dstu2FhirModelResolver modelResolver = new Dstu2FhirModelResolver();
         RestFhirRetrieveProvider retrieveProvider = new RestFhirRetrieveProvider(
                 new org.opencds.cqf.cql.engine.fhir.searchparam.SearchParameterResolver(fhirContext),
-                FhirContext.forDstu2().newRestfulGenericClient(""));
+                FhirContext.forCached(FhirVersionEnum.DSTU2).newRestfulGenericClient(""));
         CompositeDataProvider provider = new CompositeDataProvider(modelResolver, retrieveProvider);
         //BaseFhirDataProvider provider = new FhirDataProviderDstu2();
         context.registerDataProvider("http://hl7.org/fhir", provider);

--- a/engine.fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/data/FhirExecutionTestBase.java
+++ b/engine.fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/data/FhirExecutionTestBase.java
@@ -29,6 +29,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 
 import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.context.FhirVersionEnum;
 
 public abstract class FhirExecutionTestBase {
 	static Map<String, Library> libraries = new HashMap<>();
@@ -37,7 +38,7 @@ public abstract class FhirExecutionTestBase {
     protected Dstu2FhirModelResolver dstu2ModelResolver;
     protected RestFhirRetrieveProvider dstu2RetrieveProvider;
     protected CompositeDataProvider dstu2Provider;
-    
+
     protected Dstu3FhirModelResolver dstu3ModelResolver;
     protected RestFhirRetrieveProvider dstu3RetrieveProvider;
     protected CompositeDataProvider dstu3Provider;
@@ -52,19 +53,19 @@ public abstract class FhirExecutionTestBase {
     @BeforeClass
     public void setup() {
         dstu2ModelResolver = new Dstu2FhirModelResolver();
-        FhirContext dstu2Context = FhirContext.forDstu2();
+        FhirContext dstu2Context = FhirContext.forCached(FhirVersionEnum.DSTU2);
         dstu2RetrieveProvider = new RestFhirRetrieveProvider(new SearchParameterResolver(dstu2Context),
                 dstu2Context.newRestfulGenericClient("http://fhirtest.uhn.ca/baseDstu2"));
         dstu2Provider = new CompositeDataProvider(dstu2ModelResolver, dstu2RetrieveProvider);
-        
+
         dstu3ModelResolver = new Dstu3FhirModelResolver();
-        FhirContext dstu3Context = FhirContext.forDstu3();
-        dstu3RetrieveProvider = new RestFhirRetrieveProvider(new SearchParameterResolver(dstu3Context), 
+        FhirContext dstu3Context = FhirContext.forCached(FhirVersionEnum.DSTU3);
+        dstu3RetrieveProvider = new RestFhirRetrieveProvider(new SearchParameterResolver(dstu3Context),
         dstu3Context.newRestfulGenericClient("http://measure.eval.kanvix.com/cqf-ruler/baseDstu3"));
         dstu3Provider = new CompositeDataProvider(dstu3ModelResolver, dstu3RetrieveProvider);
 
         r4ModelResolver = new R4FhirModelResolver();
-        FhirContext r4Context = FhirContext.forR4();
+        FhirContext r4Context = FhirContext.forCached(FhirVersionEnum.R4);
         r4RetrieveProvider = new RestFhirRetrieveProvider(new SearchParameterResolver(r4Context),
                 r4Context.newRestfulGenericClient("http://measure.eval.kanvix.com/cqf-ruler/baseDstu4"));
         r4Provider = new CompositeDataProvider(r4ModelResolver, r4RetrieveProvider);

--- a/engine.fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/data/TestCodeRef.java
+++ b/engine.fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/data/TestCodeRef.java
@@ -6,11 +6,12 @@ import org.opencds.cqf.cql.engine.execution.Context;
 import org.opencds.cqf.cql.engine.fhir.terminology.Dstu3FhirTerminologyProvider;
 
 import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.context.FhirVersionEnum;
 import ca.uhn.fhir.rest.client.api.IGenericClient;
 
 public class TestCodeRef extends FhirExecutionTestBase {
 
-    private IGenericClient fhirClient = FhirContext.forDstu3().newRestfulGenericClient("http://measure.eval.kanvix.com/cqf-ruler/baseDstu3");
+    private IGenericClient fhirClient = FhirContext.forCached(FhirVersionEnum.DSTU3).newRestfulGenericClient("http://measure.eval.kanvix.com/cqf-ruler/baseDstu3");
     private Dstu3FhirTerminologyProvider terminologyProvider =
             new Dstu3FhirTerminologyProvider(fhirClient);
 

--- a/engine.fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/data/TestFhirDataProviderDstu3.java
+++ b/engine.fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/data/TestFhirDataProviderDstu3.java
@@ -19,11 +19,12 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.context.FhirVersionEnum;
 import ca.uhn.fhir.rest.client.api.IGenericClient;
 
 public class TestFhirDataProviderDstu3 extends FhirExecutionTestBase {
 
-    private FhirContext fhirContext = FhirContext.forDstu3();
+    private FhirContext fhirContext = FhirContext.forCached(FhirVersionEnum.DSTU3);
     private  IGenericClient fhirClient = fhirContext.newRestfulGenericClient("http://measure.eval.kanvix.com/cqf-ruler/baseDstu3");
 
     // @Test

--- a/engine.fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/data/TestFhirLibrary.java
+++ b/engine.fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/data/TestFhirLibrary.java
@@ -21,6 +21,7 @@ import org.opencds.cqf.cql.engine.fhir.retrieve.RestFhirRetrieveProvider;
 import org.opencds.cqf.cql.engine.fhir.searchparam.SearchParameterResolver;
 
 import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.context.FhirVersionEnum;
 
 public class TestFhirLibrary {
 
@@ -31,7 +32,7 @@ public class TestFhirLibrary {
 
         Context context = new Context(library);
 
-        FhirContext fhirContext = FhirContext.forDstu3();
+        FhirContext fhirContext = FhirContext.forCached(FhirVersionEnum.DSTU3);
 
 		Dstu3FhirModelResolver modelResolver = new Dstu3FhirModelResolver();
 		RestFhirRetrieveProvider retrieveProvider = new RestFhirRetrieveProvider(new SearchParameterResolver(fhirContext), fhirContext.newRestfulGenericClient("http://fhirtest.uhn.ca/baseDstu3"));
@@ -66,7 +67,7 @@ public class TestFhirLibrary {
 
         Context context = new Context(library);
 
-        FhirContext fhirContext = FhirContext.forDstu3();
+        FhirContext fhirContext = FhirContext.forCached(FhirVersionEnum.DSTU3);
 
 		Dstu3FhirModelResolver modelResolver = new Dstu3FhirModelResolver();
 		RestFhirRetrieveProvider retrieveProvider = new RestFhirRetrieveProvider(new SearchParameterResolver(fhirContext),  fhirContext.newRestfulGenericClient("http://fhirtest.uhn.ca/baseDstu3"));

--- a/engine.fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/retrieve/TestRestFhirRetrieveProvider.java
+++ b/engine.fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/retrieve/TestRestFhirRetrieveProvider.java
@@ -24,30 +24,30 @@ import org.testng.annotations.Test;
 import ca.uhn.fhir.rest.client.api.IGenericClient;
 
 public class TestRestFhirRetrieveProvider extends R4FhirTest {
-    
+
     static SearchParameterResolver RESOLVER;
     static IGenericClient CLIENT;
-    
+
     RestFhirRetrieveProvider provider;
-    
+
     @BeforeClass
     public void setUpBeforeClass() {
         CLIENT= newClient();
         RESOLVER = new SearchParameterResolver(CLIENT.getFhirContext());
     }
-    
+
     @BeforeMethod
     public void setUp() {
         this.provider = new RestFhirRetrieveProvider(RESOLVER, CLIENT);
     }
-    
-    
+
+
     @Test
     public void noUserSpecifiedPageSizeUsesDefault() {
         SearchParameterMap map = provider.getBaseMap(null, null, null);
         assertEquals( map.getCount(), null );
     }
-    
+
     @Test
     public void userSpecifiedPageSizeIsUsed() {
         Integer expected = 100;
@@ -55,73 +55,69 @@ public class TestRestFhirRetrieveProvider extends R4FhirTest {
         SearchParameterMap map = provider.getBaseMap(null, null, null);
         assertEquals( map.getCount(), expected );
     }
-    
+
     @Test
     public void userSpecifiedPageSizeIsUsedWhenCodeBasedQuery() {
         Code code = new Code().withSystem("http://mysystem.com").withCode("mycode");
         List<Code> codes = Arrays.asList( code );
-        
+
         mockFhirSearch("/Condition?code=" + escapeUrlParam(code.getSystem() + "|" + code.getCode()) + "&subject=" + escapeUrlParam("Patient/123") + "&_count=500");
-        
+
         provider.setPageSize(500);
         provider.retrieve("Patient", "subject", "123", "Condition", null, "code", codes, null, null, null, null, null);
     }
-    
+
     @Test
     public void userSpecifiedPageSizeIsUsedWhenValueSetQuery() {
-       
+
         String valueSetUrl = "http://myterm.com/fhir/ValueSet/MyValueSet";
-        
-        // TODO - This should generate an :in query, but is currently broken (See #466).
-        // I am mocking the way it works today specifically for the page size
-        // feature, but this test will need to be updated when the :in behavior
-        // starts working.
-        mockFhirSearch("/Condition?code=" + escapeUrlParam(valueSetUrl) + "&subject=" + escapeUrlParam("Patient/123") + "&_count=500");
-        
+
+        mockFhirSearch("/Condition?code" + escapeUrlParam(":") + "in=" + escapeUrlParam(valueSetUrl) + "&subject=" + escapeUrlParam("Patient/123") + "&_count=500");
+
         provider.setPageSize(500);
         provider.retrieve("Patient", "subject", "123", "Condition", "http://hl7.org/fhir/StructureDefinition/Condition", "code", null, valueSetUrl, null, null, null, null);
     }
-    
+
     @Test
     public void userSpecifiedPageSizeIsUsedWhenDateQuery() {
        /**
         * As best as I can tell, the date range optimized queries are
         * broken right now. See https://github.com/DBCG/cql_engine/issues/467.
         */
-        
+
         OffsetDateTime start = OffsetDateTime.of(2020, 11, 12, 1, 2, 3, 0, ZoneOffset.UTC);
         OffsetDateTime end = start.plusYears(1);
-        
+
         Interval interval = new Interval(new DateTime(start), true, new DateTime(end), false);
-        
+
         // The dates will be rendered in the URL in the build machine's local
         // time zone, so the URL value might fluctuate from one environment to another.
         // We could try to match that formatting logic to get an exact URL, but it isn't
         // necessary for what we are trying to achieve here, so we just accept any date
         // string.
-        mockFhirInteraction(get(urlMatching("/Condition\\?subject=" + escapeUrlParam("Patient/123") + 
-                "&onset-date=ge2020[^&]+&onset-date=le[^&]+" + 
+        mockFhirInteraction(get(urlMatching("/Condition\\?subject=" + escapeUrlParam("Patient/123") +
+                "&onset-date=ge2020[^&]+&onset-date=le[^&]+" +
                 "&_count=500")), makeBundle());
-        
+
         provider.setPageSize(500);
         provider.retrieve("Patient", "subject", "123", "Condition", null, "code", null, null, "onset", null, null, interval);
-    } 
-    
+    }
+
     @Test
     public void userSpecifiedPageSizeNotUsedWhenIDQuery() {
         mockFhirRead("/Patient/123", new Patient());
-        
+
         provider.setPageSize(500);
         provider.retrieve("Patient", "id", "123", "Patient", "http://hl7.org/fhir/StructureDefinition/Patient", null, null, null, null, null, null, null);
     }
-    
+
     @Test
     public void noUserSpecifiedPageSizeSpecifiedNoCountInURL() {
         Code code = new Code().withSystem("http://mysystem.com").withCode("mycode");
         List<Code> codes = Arrays.asList( code );
-        
+
         mockFhirSearch("/Condition?code=" + escapeUrlParam(code.getSystem() + "|" + code.getCode()) + "&subject=" + escapeUrlParam("Patient/123"));
-        
+
         provider.retrieve("Patient", "subject", "123", "Condition", null, "code", codes, null, null, null, null, null);
     }
 }

--- a/engine.fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/searchparam/TestSearchParameterResolver.java
+++ b/engine.fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/searchparam/TestSearchParameterResolver.java
@@ -8,6 +8,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.testng.annotations.Test;
 
 import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.context.FhirVersionEnum;
 import ca.uhn.fhir.context.RuntimeSearchParam;
 import ca.uhn.fhir.model.api.IQueryParameterType;
 import ca.uhn.fhir.rest.api.RestSearchParameterTypeEnum;
@@ -15,7 +16,7 @@ import ca.uhn.fhir.rest.api.RestSearchParameterTypeEnum;
 public class TestSearchParameterResolver {
     @Test
     public void testReturnsNullPathReturnsNull() {
-        SearchParameterResolver resolver = new SearchParameterResolver(FhirContext.forDstu3());
+        SearchParameterResolver resolver = new SearchParameterResolver(FhirContext.forCached(FhirVersionEnum.DSTU3));
 
         RuntimeSearchParam param = resolver.getSearchParameterDefinition("Patient", null);
         assertNull(param);
@@ -23,7 +24,7 @@ public class TestSearchParameterResolver {
 
     @Test
     public void testNullDataTypeReturnsNull() {
-        SearchParameterResolver resolver = new SearchParameterResolver(FhirContext.forDstu3());
+        SearchParameterResolver resolver = new SearchParameterResolver(FhirContext.forCached(FhirVersionEnum.DSTU3));
 
         RuntimeSearchParam param = resolver.getSearchParameterDefinition(null, "code");
         assertNull(param);
@@ -31,7 +32,7 @@ public class TestSearchParameterResolver {
 
     @Test
     void testDstu3SearchParams() {
-        SearchParameterResolver resolver = new SearchParameterResolver(FhirContext.forDstu3());
+        SearchParameterResolver resolver = new SearchParameterResolver(FhirContext.forCached(FhirVersionEnum.DSTU3));
 
         RuntimeSearchParam param = resolver.getSearchParameterDefinition("Patient", "id");
         assertNotNull(param);
@@ -66,7 +67,7 @@ public class TestSearchParameterResolver {
 
     @Test
     void testDstu3DateSearchParams() {
-        SearchParameterResolver resolver = new SearchParameterResolver(FhirContext.forDstu3());
+        SearchParameterResolver resolver = new SearchParameterResolver(FhirContext.forCached(FhirVersionEnum.DSTU3));
 
         RuntimeSearchParam param = resolver.getSearchParameterDefinition("ProcedureRequest", "authoredOn",
                 RestSearchParameterTypeEnum.DATE);
@@ -76,7 +77,7 @@ public class TestSearchParameterResolver {
 
     @Test
     void testR4SearchParams() {
-        SearchParameterResolver resolver = new SearchParameterResolver(FhirContext.forR4());
+        SearchParameterResolver resolver = new SearchParameterResolver(FhirContext.forCached(FhirVersionEnum.R4));
 
         RuntimeSearchParam param = resolver.getSearchParameterDefinition("Patient", "id");
         assertNotNull(param);
@@ -119,25 +120,25 @@ public class TestSearchParameterResolver {
 
     @Test
     void testR4DateSearchParams() {
-        SearchParameterResolver resolver = new SearchParameterResolver(FhirContext.forR4());
+        SearchParameterResolver resolver = new SearchParameterResolver(FhirContext.forCached(FhirVersionEnum.R4));
 
         RuntimeSearchParam param = resolver.getSearchParameterDefinition("ServiceRequest", "authoredOn",
                 RestSearchParameterTypeEnum.DATE);
         assertNotNull(param);
         assertEquals("authored", param.getName());
-        
+
         param = resolver.getSearchParameterDefinition("Condition", "onset", RestSearchParameterTypeEnum.DATE);
         assertNotNull(param);
         assertEquals("onset-date", param.getName());
-        
+
         param = resolver.getSearchParameterDefinition("Condition", "abatement", RestSearchParameterTypeEnum.DATE);
         assertNotNull(param);
         assertEquals("abatement-date", param.getName());
-        
+
         param = resolver.getSearchParameterDefinition("Observation", "effective", RestSearchParameterTypeEnum.DATE);
         assertNotNull(param);
         assertEquals("date", param.getName());
-        
+
         param = resolver.getSearchParameterDefinition("Observation", "value", RestSearchParameterTypeEnum.DATE);
         assertNotNull(param);
         assertEquals("value-date", param.getName());
@@ -145,7 +146,7 @@ public class TestSearchParameterResolver {
 
     @Test
     void testR4ReferenceParameter() {
-        FhirContext context = FhirContext.forR4();
+        FhirContext context = FhirContext.forCached(FhirVersionEnum.R4);
         SearchParameterResolver resolver = new SearchParameterResolver(context);
         Pair<String, IQueryParameterType> actual = resolver.createSearchParameter("Patient", "Observation", "subject",
                 "123");
@@ -155,7 +156,7 @@ public class TestSearchParameterResolver {
 
     @Test
     void testR4TokenParameter() {
-        FhirContext context = FhirContext.forR4();
+        FhirContext context = FhirContext.forCached(FhirVersionEnum.R4);
         SearchParameterResolver resolver = new SearchParameterResolver(context);
         Pair<String, IQueryParameterType> actual = resolver.createSearchParameter("Patient", "Observation", "code",
                 "123");

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <jackson.version>2.12.3</jackson.version>
         <cqframework.version>1.5.3</cqframework.version>
-        <hapi.version>5.3.2</hapi.version>
+        <hapi.version>5.4.0</hapi.version>
         <slf4j.version>1.7.29</slf4j.version>
     </properties>
 
@@ -260,7 +260,7 @@
             <dependency>
                 <groupId>com.github.tomakehurst</groupId>
                 <artifactId>wiremock-jre8</artifactId>
-                <version>2.27.2</version>
+                <version>2.28.0</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>


### PR DESCRIPTION
* Update to HAPI 5.4
* Fix tests for "code:in" queries
* Add context caching where appropriate
* Resolves cqframework/clinical_quality_language#917 