### PR TITLE
#479 - add support in ModelResolver for multiple package names

### DIFF
--- a/engine.fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/model/FhirModelResolver.java
+++ b/engine.fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/model/FhirModelResolver.java
@@ -164,11 +164,13 @@ public abstract class FhirModelResolver<BaseType, BaseDateTimeType, TimeType, Si
         return createInstance(resolveType(typeName));
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public String getPackageName() {
         return packageName;
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public void setPackageName(String packageName) {
         this.packageName = packageName;

--- a/engine/src/main/java/org/opencds/cqf/cql/engine/data/CompositeDataProvider.java
+++ b/engine/src/main/java/org/opencds/cqf/cql/engine/data/CompositeDataProvider.java
@@ -1,5 +1,7 @@
 package org.opencds.cqf.cql.engine.data;
 
+import java.util.List;
+
 import org.opencds.cqf.cql.engine.model.ModelResolver;
 import org.opencds.cqf.cql.engine.retrieve.RetrieveProvider;
 import org.opencds.cqf.cql.engine.runtime.Code;
@@ -15,15 +17,26 @@ public class CompositeDataProvider implements DataProvider {
         this.retrieveProvider = retrieveProvider;
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public String getPackageName() {
         return this.modelResolver.getPackageName();
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public void setPackageName(String packageName) {
         this.modelResolver.setPackageName(packageName);
+    }
 
+    @Override
+    public List<String> getPackageNames() {
+        return this.modelResolver.getPackageNames();
+    }
+
+    @Override
+    public void setPackageNames(List<String> packageNames) {
+        this.modelResolver.setPackageNames(packageNames);
     }
 
     @Override

--- a/engine/src/main/java/org/opencds/cqf/cql/engine/data/SystemDataProvider.java
+++ b/engine/src/main/java/org/opencds/cqf/cql/engine/data/SystemDataProvider.java
@@ -29,11 +29,13 @@ public class SystemDataProvider extends BaseModelResolver implements DataProvide
 	// 	return false;
 	// }
 
-	@Override
+    @SuppressWarnings("deprecation")
+    @Override
     public String getPackageName() {
         return "org.opencds.cqf.cql.engine.runtime";
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public void setPackageName(String packageName) {
 

--- a/engine/src/main/java/org/opencds/cqf/cql/engine/execution/Context.java
+++ b/engine/src/main/java/org/opencds/cqf/cql/engine/execution/Context.java
@@ -544,8 +544,14 @@ public class Context {
         if (ret != null) {
             return ret;
         }
-        throw new CqlException(String.format("Could not resolve call to operator '%s' in library '%s'.",
-                name, getCurrentLibrary().getIdentifier().getId()));
+        
+        StringBuilder argStr = new StringBuilder();
+        if( arguments != null ) {
+            arguments.forEach( a -> argStr.append( (argStr.length() > 0) ? ", " : "" ).append( resolveType(a).getName() ) );
+        }
+        
+        throw new CqlException(String.format("Could not resolve call to operator '%s(%s)' in library '%s'.",
+                name, argStr.toString(), getCurrentLibrary().getIdentifier().getId()));
     }
 
     private ParameterDef resolveParameterRef(String name) {
@@ -635,7 +641,7 @@ public class Context {
 
     public void registerDataProvider(String modelUri, DataProvider dataProvider) {
         dataProviders.put(modelUri, dataProvider);
-        packageMap.put(dataProvider.getPackageName(), dataProvider);
+        dataProvider.getPackageNames().forEach( pn -> packageMap.put( pn, dataProvider ) );
     }
 
     public DataProvider resolveDataProvider(QName dataType) {
@@ -652,6 +658,7 @@ public class Context {
         return resolveDataProvider(packageName, true);
     }
 
+    @SuppressWarnings("deprecation")
     public DataProvider resolveDataProvider(String packageName, boolean mustResolve) {
         DataProvider dataProvider = packageMap.get(packageName);
         if (dataProvider == null) {

--- a/engine/src/main/java/org/opencds/cqf/cql/engine/model/ModelResolver.java
+++ b/engine/src/main/java/org/opencds/cqf/cql/engine/model/ModelResolver.java
@@ -1,29 +1,150 @@
 package org.opencds.cqf.cql.engine.model;
 
+import java.util.Collections;
+import java.util.List;
 
+/**
+ * A ModelResolver provides support for mapping a logical model (e.g. QDM or FHIR)
+ * onto a Java implementation of that model. Different implementations of the same
+ * model might map to different implementation schemes with the simplest example
+ * being classes in different package names, but also possibly with different property
+ * naming schemes, etc.
+ */
 public interface ModelResolver {
+
+    /**
+     * @deprecated Use getPackageNames() instead
+     */
     String getPackageName();
 
+    /**
+     * @deprecated Use setPackageNames#String instead
+     */
     void setPackageName(String packageName);
 
-    // Expected to return null whenever a path doesn't exist on the target.
+    /**
+     * Return the package names of Java objects supported by this model
+     *
+     * @return list of Java package names for model objects that 
+     * support this model.
+     */
+    default List<String> getPackageNames() {
+        return Collections.singletonList( getPackageName() );
+    }
+
+    /**
+     * Set the package names of Java objects supported by this model
+     *
+     * @param packageNames list of Java package names for model objects
+     * that support this model.
+     */
+    default void setPackageNames(List<String> packageNames) {
+        // Intentionally empty. This provides backwards
+        // compatability for models that implement a single
+        // package name and still use the get/setPackageName
+        // methods.
+    }
+
+    /**
+     * Resolve the provided path expression for the provided target. Paths
+     * can be things like simple dotted property notation (e.g. Patient.id)
+     * or more complex things like list indexed property expressions
+     * (e.g. Patient.name[0].given). The exact details are configued in the
+     * model definition and passed to the ELM file during CQL to ELM
+     * translation.
+     *
+     * @return result of the provided expression. Null is expected whenever a path doesn't 
+     * exist on the target.
+     */
     Object resolvePath(Object target, String path);
 
+    /**
+     * Get the path expression that expresses the relationship between
+     * the <code>targetType</code> and the given <code>contextType</code>.
+     * For example, in a FHIR model, with context type <code>Patient</code> and
+     * targetType Condition, the resulting path is <code>subject</code>
+     * because that is the model property on the Condition object
+     * that links the Condition to the Patient.
+     */
     Object getContextPath(String contextType, String targetType);
 
+    /**
+     * Resolve the Java class that corresponds to the given model type
+     *
+     * @param typeName Model type name. In the ELM, model objects
+     * are namespaced (e.g. FHIR.Patient), but the namespace is 
+     * removed prior to calling this method, so the input would just
+     * be Patient.
+     * @return Class object that represents the specified model type
+     */
     Class<?> resolveType(String typeName);
 
+    /**
+     * Resolve the Java class that corresponds to the given model object
+     * instance.
+     *
+     * @param value Object instance
+     * @return Class object that represents the specified value
+     */
     Class<?> resolveType(Object value);
 
+    /**
+     * Check whether or not a specified value instance is of the 
+     * specified type.
+     *
+     * @param value
+     * @param type
+     * @return true when the value is of the specified type, otherwise false.
+     */
     Boolean is(Object value, Class<?> type);
 
+    /**
+     * Cast the specified value to the specified type. When type 
+     * conversion is not possible, null should be returned unless
+     * the isStrict flag is set to true wherein an Exception will
+     * be thrown.
+     *
+     * @param value model object instance
+     * @param type type to which the value should be case
+     * @param isStrict flag indicating how to handle invalid type conversion
+     * @return the result of the value conversion or null if conversion is not possible.
+     */
     Object as(Object value, Class<?> type, boolean isStrict);
 
-	Object createInstance(String typeName);
+    /**
+     * Create an instance of the model object that corresponds
+     * to the specified type.
+     *
+     * @param typeName Model type to create
+     * @return new instance of the specified model type
+     */
+    Object createInstance(String typeName);
 
+    /**
+     * Set the value of a particular property on the given
+     * model object.
+     *
+     * @param target model object
+     * @param path path to the property that will be set
+     * @param value value to set to the property indicated by the path expression
+     */
     void setValue(Object target, String path, Object value);
 
+    /**
+     * Compare two objects for equality
+     *
+     * @param left left hand side of the equality expression
+     * @param right right hand side of the equality expression
+     * @return flag indicating whether the objects are equal
+     */
     Boolean objectEqual(Object left, Object right);
 
+    /**
+     * Compare two objects for equivalence
+     *
+     * @param left left hand side of the equivalence expression
+     * @param right right hand side of the equivalence expression
+     * @return flag indicating whether the objects are equal
+     */
     Boolean objectEquivalent(Object left, Object right);
 }


### PR DESCRIPTION
I added getPackageNames/setPackageNames to the ModelResolver interface and tagged the old methods as @deprecated. Since I had to add javadoc, I went ahead and made an attempt to document the entire interface.