### PR TITLE
Fix exists with nulls in list

### DIFF
--- a/engine/src/main/java/org/opencds/cqf/cql/engine/elm/execution/ExistsEvaluator.java
+++ b/engine/src/main/java/org/opencds/cqf/cql/engine/elm/execution/ExistsEvaluator.java
@@ -20,7 +20,7 @@ public class ExistsEvaluator extends org.cqframework.cql.elm.execution.Exists {
             return false;
         }
 
-        return !CqlList.toList(value, true).isEmpty();
+        return !CqlList.toList(value, false).isEmpty();
     }
 
     @Override

--- a/engine/src/test/java/org/opencds/cqf/cql/engine/execution/CqlListOperatorsTest.java
+++ b/engine/src/test/java/org/opencds/cqf/cql/engine/execution/CqlListOperatorsTest.java
@@ -253,7 +253,7 @@ public class CqlListOperatorsTest extends CqlExecutionTestBase {
         assertThat(result, is(false));
 
         result = context.resolveExpressionRef("ExistsListNull").getExpression().evaluate(context);
-        assertThat(result, is(true));
+        assertThat(result, is(false));
 
         result = context.resolveExpressionRef("Exists1").getExpression().evaluate(context);
         assertThat(result, is(true));


### PR DESCRIPTION
* Fix behavior of `exists()` with lists of nulls
* Resolves cqframework/clinical_quality_language#907 