### PR TITLE
Fix interval toString

### DIFF
--- a/engine/src/main/java/org/opencds/cqf/cql/engine/runtime/Interval.java
+++ b/engine/src/main/java/org/opencds/cqf/cql/engine/runtime/Interval.java
@@ -195,13 +195,10 @@ public class Interval implements CqlType, Comparable<Interval> {
 
     @Override
     public String toString() {
-        if (getStart() == null) {
-
-        }
         return String.format("Interval%s%s, %s%s",
                 getLowClosed() ? "[" : "(",
-                getStart() == null ? "null" : getStart().toString(),
-                getEnd() == null ? "null" : getEnd().toString(),
+                getLow() == null ? "null" : getLow().toString(),
+                getHigh() == null ? "null" : getHigh().toString(),
                 getHighClosed() ? "]" : ")"
         );
     }

--- a/engine/src/test/java/org/opencds/cqf/cql/engine/execution/Issue458.java
+++ b/engine/src/test/java/org/opencds/cqf/cql/engine/execution/Issue458.java
@@ -1,0 +1,18 @@
+package org.opencds.cqf.cql.engine.execution;
+
+import static org.testng.Assert.assertEquals;
+
+
+import org.opencds.cqf.cql.engine.runtime.Interval;
+import org.testng.annotations.Test;
+
+public class Issue458 extends CqlExecutionTestBase {
+    @Test
+    public void testInterval() {
+        Context context = new Context(library);
+
+        Object result = context.resolveExpressionRef("Closed-Open Interval").getExpression().evaluate(context);
+        Interval interval = (Interval)result;
+        assertEquals(interval.toString(), "Interval[3, 5)");
+    }
+}

--- a/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/Issue458.cql
+++ b/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/Issue458.cql
@@ -1,0 +1,5 @@
+library Issue458 version '1'
+
+define "Closed-Open Interval":
+  Interval[3, 5)
+


### PR DESCRIPTION
* Fixes the Interval "ToString" to show the original values and boundaries
* Resolved cqframework/clinical_quality_language#922 