### PR TITLE
add expression cache clear method

### DIFF
--- a/engine/src/main/java/org/opencds/cqf/cql/engine/execution/Context.java
+++ b/engine/src/main/java/org/opencds/cqf/cql/engine/execution/Context.java
@@ -77,6 +77,10 @@ public class Context {
         };
     }
 
+    public void enableExpressionCache() {
+        this.expressions.clear();
+    }
+
     private List<Object> evaluatedResources = new ArrayList<>();
     public List<Object> getEvaluatedResources() {
         return evaluatedResources;


### PR DESCRIPTION
There's an old pr in https://github.com/DBCG/cqf-ruler/pull/154 that exposes this `clear` through reflection and `setAccessible`,
but I believe this pattern is being deprecated in `java 9` and "hard disabled in release 11" (https://stackoverflow.com/a/60241952)

Would it be alright if we just exposed that functionality directly to preserve compatibility?
