### PR TITLE
clear expression cache when context parameters change

### DIFF
--- a/engine/src/main/java/org/opencds/cqf/cql/engine/execution/Context.java
+++ b/engine/src/main/java/org/opencds/cqf/cql/engine/execution/Context.java
@@ -136,6 +136,10 @@ public class Context {
         }
     }
 
+    public void clearExpressions() {
+        this.expressions.clear();
+    }
+
     public void logDebugResult(Executable node, Object result, DebugAction action) {
         ensureDebugResult();
         debugResult.logDebugResult(node, this.getCurrentLibrary(), result, action);
@@ -185,6 +189,8 @@ public class Context {
         pushWindow();
         registerDataProvider("urn:hl7-org:elm-types:r1", systemDataProvider);
         libraryLoader = new DefaultLibraryLoader();
+        this.clearExpressions();
+
         if (library.getIdentifier() != null)
             libraries.put(library.getIdentifier().getId(), library);
         currentLibrary.push(library);
@@ -544,12 +550,12 @@ public class Context {
         if (ret != null) {
             return ret;
         }
-        
+
         StringBuilder argStr = new StringBuilder();
         if( arguments != null ) {
             arguments.forEach( a -> argStr.append( (argStr.length() > 0) ? ", " : "" ).append( resolveType(a).getName() ) );
         }
-        
+
         throw new CqlException(String.format("Could not resolve call to operator '%s(%s)' in library '%s'.",
                 name, argStr.toString(), getCurrentLibrary().getIdentifier().getId()));
     }

--- a/engine/src/main/java/org/opencds/cqf/cql/engine/execution/Context.java
+++ b/engine/src/main/java/org/opencds/cqf/cql/engine/execution/Context.java
@@ -571,6 +571,7 @@ public class Context {
     }
 
     public void setParameter(String libraryName, String name, Object value) {
+        clearExpressions();
         boolean enteredLibrary = enterLibrary(libraryName);
         try {
             String fullName = libraryName != null ? String.format("%s.%s", getCurrentLibrary().getIdentifier().getId(), name) : name;
@@ -730,6 +731,7 @@ public class Context {
     }
 
     public void setContextValue(String context, Object contextValue) {
+        clearExpressions();
         contextValues.put(context, contextValue);
     }
 

--- a/engine/src/main/java/org/opencds/cqf/cql/engine/execution/Context.java
+++ b/engine/src/main/java/org/opencds/cqf/cql/engine/execution/Context.java
@@ -189,7 +189,6 @@ public class Context {
         pushWindow();
         registerDataProvider("urn:hl7-org:elm-types:r1", systemDataProvider);
         libraryLoader = new DefaultLibraryLoader();
-        this.clearExpressions();
 
         if (library.getIdentifier() != null)
             libraries.put(library.getIdentifier().getId(), library);

--- a/engine/src/main/java/org/opencds/cqf/cql/engine/execution/Context.java
+++ b/engine/src/main/java/org/opencds/cqf/cql/engine/execution/Context.java
@@ -571,7 +571,6 @@ public class Context {
     }
 
     public void setParameter(String libraryName, String name, Object value) {
-        clearExpressions();
         boolean enteredLibrary = enterLibrary(libraryName);
         try {
             String fullName = libraryName != null ? String.format("%s.%s", getCurrentLibrary().getIdentifier().getId(), name) : name;
@@ -731,8 +730,17 @@ public class Context {
     }
 
     public void setContextValue(String context, Object contextValue) {
-        clearExpressions();
+        if (hasContextValueChanged(context, contextValue)) {
+            clearExpressions();
+        }
         contextValues.put(context, contextValue);
+    }
+
+    private boolean hasContextValueChanged(String context, Object contextValue) {
+        if (contextValues.containsKey(context)) {
+            return !contextValues.get(context).equals(contextValue);
+        }
+        return true;
     }
 
     public Object getCurrentContextValue() {

--- a/engine/src/main/java/org/opencds/cqf/cql/engine/execution/CqlEngine.java
+++ b/engine/src/main/java/org/opencds/cqf/cql/engine/execution/CqlEngine.java
@@ -191,6 +191,10 @@ public class CqlEngine {
     }
 
     private void setParametersForContext(Library library, Context context, Pair<String, Object> contextParameter, Map<String, Object> parameters) {
+        if(context != null) {
+            context.clearExpressions();
+        }
+
         if (contextParameter != null) {
             context.setContextValue(contextParameter.getLeft(), contextParameter.getRight());
         }

--- a/engine/src/main/java/org/opencds/cqf/cql/engine/execution/CqlEngine.java
+++ b/engine/src/main/java/org/opencds/cqf/cql/engine/execution/CqlEngine.java
@@ -195,10 +195,6 @@ public class CqlEngine {
     }
 
     private void setParametersForContext(Library library, Context context, Pair<String, Object> contextParameter, Map<String, Object> parameters) {
-        if(context != null) {
-            context.clearExpressions();
-        }
-
         if (contextParameter != null) {
             context.setContextValue(contextParameter.getLeft(), contextParameter.getRight());
         }

--- a/engine/src/main/java/org/opencds/cqf/cql/engine/execution/CqlEngine.java
+++ b/engine/src/main/java/org/opencds/cqf/cql/engine/execution/CqlEngine.java
@@ -187,14 +187,14 @@ public class CqlEngine {
 
         result.setDebugResult(context.getDebugResult());
 
-        return result;
-    }
-
-    private void setParametersForContext(Library library, Context context, Pair<String, Object> contextParameter, Map<String, Object> parameters) {
         if(context != null) {
             context.clearExpressions();
         }
 
+        return result;
+    }
+
+    private void setParametersForContext(Library library, Context context, Pair<String, Object> contextParameter, Map<String, Object> parameters) {
         if (contextParameter != null) {
             context.setContextValue(contextParameter.getLeft(), contextParameter.getRight());
         }

--- a/engine/src/main/java/org/opencds/cqf/cql/engine/execution/CqlEngine.java
+++ b/engine/src/main/java/org/opencds/cqf/cql/engine/execution/CqlEngine.java
@@ -195,6 +195,10 @@ public class CqlEngine {
     }
 
     private void setParametersForContext(Library library, Context context, Pair<String, Object> contextParameter, Map<String, Object> parameters) {
+        if(context != null) {
+            context.clearExpressions();
+        }
+
         if (contextParameter != null) {
             context.setContextValue(contextParameter.getLeft(), contextParameter.getRight());
         }


### PR DESCRIPTION
https://github.com/DBCG/cql_engine/issues/273
I have tested, it clears the expressions map in Context when evaluation ends. 