### PR TITLE
Verify the `Interval except` produce correct output

### DIFF
--- a/engine/src/test/java/org/opencds/cqf/cql/engine/execution/CqlIntervalOperatorsTest.java
+++ b/engine/src/test/java/org/opencds/cqf/cql/engine/execution/CqlIntervalOperatorsTest.java
@@ -385,6 +385,12 @@ public class CqlIntervalOperatorsTest extends CqlExecutionTestBase {
         result = context.resolveExpressionRef("IntegerIntervalExcept1to3").getExpression().evaluate(context);
         Assert.assertTrue(((Interval)result).equal(new Interval(1, true, 3, true)));
 
+        result = context.resolveExpressionRef("IntegerIntervalExcept4to6").getExpression().evaluate(context);
+        Assert.assertTrue(((Interval)result).equal(new Interval(-4, false, 6, false)));
+
+        result = context.resolveExpressionRef("IntegerIntervalExceptNullOutNull").getExpression().evaluate(context);
+        assertThat(result, is(nullValue()));
+
         result = context.resolveExpressionRef("IntegerIntervalExceptNull").getExpression().evaluate(context);
         assertThat(result, is(nullValue()));
 
@@ -477,7 +483,7 @@ public class CqlIntervalOperatorsTest extends CqlExecutionTestBase {
     }
 
     /**
-     * {@link org.opencds.cqf.cql.elm.execution.IncludesEvaluator#evaluate(Context)}
+     * {@link org.opencds.cqf.cql.engine.elm.execution.IncludesEvaluator#evaluate(Context)}
      */
     @Test
     public void TestIncludes() {

--- a/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/CqlIntervalOperatorsTest.cql
+++ b/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/CqlIntervalOperatorsTest.cql
@@ -119,7 +119,9 @@ define TimeEqualFalse: Interval[@T05:59:59.999, @T10:59:59.999] = Interval[@T05:
 //Except
 define TestExceptNull: null as Interval<Integer> except null as Interval<Integer>
 define IntegerIntervalExcept1to3: IntegerIntervalTest except IntegerIntervalTest4
+define IntegerIntervalExcept4to6: IntegerIntervalTest6 except IntegerIntervalTest7
 define IntegerIntervalExceptNull: Interval[1, 10] except Interval[3, 7]
+define IntegerIntervalExceptNullOutNull: Interval[1, 10] except null as Interval<Integer>
 define DecimalIntervalExcept1to3: DecimalIntervalTest except DecimalIntervalTest3
 define DecimalIntervalExceptNull: Interval[1.0, 10.0] except Interval[3.0, 7.0]
 define QuantityIntervalExcept1to4: QuantityIntervalTest except QuantityIntervalTest3
@@ -423,6 +425,8 @@ define IntegerIntervalTest2: Interval[11, 20]
 define IntegerIntervalTest3: Interval[44, 50]
 define IntegerIntervalTest4: Interval[4, 10]
 define IntegerIntervalTest5: Interval[4, 15]
+define IntegerIntervalTest6: Interval(-4, 6)
+define IntegerIntervalTest7: Interval(7, 12)
 define DecimalIntervalTest: Interval[1.0, 10.0]
 define DecimalIntervalTest2: Interval[11.0, 20.0]
 define DecimalIntervalTest3: Interval[4.0, 10.0]


### PR DESCRIPTION
Refer to issue: https://github.com/DBCG/cql_engine/issues/403
The issue was: 
_define "test": Interval(-4, 6) except Interval(7, 12) //calculates to Interval(-3, 5)_
Actually as of now(July 16 2021) the engine produces correct result `Interval(-4,6)`. The same test has been added in this PR