### PR TITLE
add Type conversion for complex arithmetic expression

### DIFF
--- a/engine/src/main/java/org/opencds/cqf/cql/engine/elm/execution/ArithmeticUtil.java
+++ b/engine/src/main/java/org/opencds/cqf/cql/engine/elm/execution/ArithmeticUtil.java
@@ -1,5 +1,6 @@
 package org.opencds.cqf.cql.engine.elm.execution;
 
+import java.math.BigDecimal;
 import java.util.HashMap;
 
 public class ArithmeticUtil {
@@ -11,7 +12,7 @@ public class ArithmeticUtil {
         TYPE_WEIGHT.put("BigDecimal", 3);
     }
 
-    public static String determineClassTypeForArithmetic(Object left, Object right) {
+    public static String determineResultTypeForArithmetic(Object left, Object right) {
         String leftType = left.getClass().getSimpleName();
         String rightType = right.getClass().getSimpleName();
 
@@ -24,5 +25,26 @@ public class ArithmeticUtil {
         } else {
             return "";
         }
+    }
+
+    public static Object convertToLong(Object operand) {
+        if (!(operand instanceof Long)) {
+            return ToLongEvaluator.toLong(operand);
+        }
+        return operand;
+    }
+
+    public static Object convertToInteger(Object operand) {
+        if (!(operand instanceof Integer)) {
+            return ToIntegerEvaluator.toInteger(operand);
+        }
+        return operand;
+    }
+
+    public static Object convertToDecimal(Object operand) {
+        if (!(operand instanceof BigDecimal)) {
+            return ToDecimalEvaluator.toDecimal(operand);
+        }
+        return operand;
     }
 }

--- a/engine/src/main/java/org/opencds/cqf/cql/engine/elm/execution/ArithmeticUtil.java
+++ b/engine/src/main/java/org/opencds/cqf/cql/engine/elm/execution/ArithmeticUtil.java
@@ -1,0 +1,28 @@
+package org.opencds.cqf.cql.engine.elm.execution;
+
+import java.util.HashMap;
+
+public class ArithmeticUtil {
+
+    private static HashMap<String, Integer> TYPE_WEIGHT = new HashMap<>();
+    static {
+        TYPE_WEIGHT.put("Integer", 1);
+        TYPE_WEIGHT.put("Long", 2);
+        TYPE_WEIGHT.put("BigDecimal", 3);
+    }
+
+    public static String determineClassTypeForArithmetic(Object left, Object right) {
+        String leftType = left.getClass().getSimpleName();
+        String rightType = right.getClass().getSimpleName();
+
+        if (TYPE_WEIGHT.containsKey(leftType) && TYPE_WEIGHT.containsKey(rightType)) {
+
+            if (TYPE_WEIGHT.get(leftType) >= TYPE_WEIGHT.get(rightType)) {
+                return leftType;
+            }
+            return rightType;
+        } else {
+            return "";
+        }
+    }
+}

--- a/engine/src/main/java/org/opencds/cqf/cql/engine/elm/execution/MultiplyEvaluator.java
+++ b/engine/src/main/java/org/opencds/cqf/cql/engine/elm/execution/MultiplyEvaluator.java
@@ -32,7 +32,7 @@ public class MultiplyEvaluator extends org.cqframework.cql.elm.execution.Multipl
             return null;
         }
 
-        String type = ArithmeticUtil.determineClassTypeForArithmetic(left, right);
+        String type = ArithmeticUtil.determineResultTypeForArithmetic(left, right);
         Object returnValue = null;
 
         if(!type.isEmpty()) {
@@ -87,32 +87,21 @@ public class MultiplyEvaluator extends org.cqframework.cql.elm.execution.Multipl
     }
 
     private static Object calculateIntegerMultiply(Object left, Object right) {
-        if(!(left instanceof Integer)) {
-            left = ToIntegerEvaluator.toInteger(left);
-        }
-        if(!(right instanceof Integer)) {
-            right = ToIntegerEvaluator.toInteger(right);
-        }
+        left = ArithmeticUtil.convertToInteger(left);
+        right = ArithmeticUtil.convertToInteger(right);
+
         return (Integer) left * (Integer) right;
     }
 
     private static Object calculateLongMultiply(Object left, Object right) {
-        if(!(left instanceof Long)) {
-            left = ToLongEvaluator.toLong(left);
-        }
-        if(!(right instanceof Long)) {
-            right = ToLongEvaluator.toLong(right);
-        }
+        left = ArithmeticUtil.convertToLong(left);
+        right = ArithmeticUtil.convertToLong(right);
         return (Long) left * (Long) right;
     }
 
     private static Object calculateDecimalMultiply(Object left, Object right) {
-        if(!(left instanceof BigDecimal)) {
-            left = ToDecimalEvaluator.toDecimal(left);
-        }
-        if(!(right instanceof BigDecimal)) {
-            right = ToDecimalEvaluator.toDecimal(right);
-        }
+        left = ArithmeticUtil.convertToDecimal(left);
+        right = ArithmeticUtil.convertToDecimal(right);
         return Value.verifyPrecision(((BigDecimal) left).multiply((BigDecimal) right), null);
     }
 

--- a/engine/src/main/java/org/opencds/cqf/cql/engine/elm/execution/PowerEvaluator.java
+++ b/engine/src/main/java/org/opencds/cqf/cql/engine/elm/execution/PowerEvaluator.java
@@ -22,7 +22,7 @@ public class PowerEvaluator extends org.cqframework.cql.elm.execution.Power {
             return null;
         }
 
-        String type = ArithmeticUtil.determineClassTypeForArithmetic(left, right);
+        String type = ArithmeticUtil.determineResultTypeForArithmetic(left, right);
         Object returnValue = null;
 
         switch(type) {
@@ -49,12 +49,8 @@ public class PowerEvaluator extends org.cqframework.cql.elm.execution.Power {
     }
 
     private static Object calculateIntegerPower(Object left, Object right) {
-        if(!(left instanceof Integer)) {
-            left = ToIntegerEvaluator.toInteger(left);
-        }
-        if(!(right instanceof Integer)) {
-            right = ToIntegerEvaluator.toInteger(right);
-        }
+        left = ArithmeticUtil.convertToInteger(left);
+        right = ArithmeticUtil.convertToInteger(right);
 
         if ((Integer) right < 0) {
             return new BigDecimal(1).divide(new BigDecimal((Integer) left).pow(Math.abs((Integer) right)));
@@ -63,12 +59,9 @@ public class PowerEvaluator extends org.cqframework.cql.elm.execution.Power {
     }
 
     private static Object calculateLongPower(Object left, Object right) {
-        if(!(left instanceof Long)) {
-            left = ToLongEvaluator.toLong(left);
-        }
-        if(!(right instanceof Long)) {
-            right = ToLongEvaluator.toLong(right);
-        }
+        left = ArithmeticUtil.convertToLong(left);
+        right = ArithmeticUtil.convertToLong(right);
+
         if ((Long) right < 0) {
             return new BigDecimal(1).divide(new BigDecimal((Long) left).pow(Math.abs((Integer) right)));
         }
@@ -76,12 +69,9 @@ public class PowerEvaluator extends org.cqframework.cql.elm.execution.Power {
     }
 
     private static BigDecimal calculateDecimalPower(Object left, Object right) {
-        if(!(left instanceof BigDecimal)) {
-            left = ToDecimalEvaluator.toDecimal(left);
-        }
-        if(!(right instanceof BigDecimal)) {
-            right = ToDecimalEvaluator.toDecimal(right);
-        }
+        left = ArithmeticUtil.convertToDecimal(left);
+        right = ArithmeticUtil.convertToDecimal(right);
+
         return Value.verifyPrecision(new BigDecimal(Math.pow((((BigDecimal) left).doubleValue()), ((BigDecimal) right).doubleValue())), null);
     }
 

--- a/engine/src/main/java/org/opencds/cqf/cql/engine/elm/execution/PowerEvaluator.java
+++ b/engine/src/main/java/org/opencds/cqf/cql/engine/elm/execution/PowerEvaluator.java
@@ -22,30 +22,70 @@ public class PowerEvaluator extends org.cqframework.cql.elm.execution.Power {
             return null;
         }
 
-        if (left instanceof Integer) {
-            if ((Integer)right < 0) {
-                return new BigDecimal(1).divide(new BigDecimal((Integer)left).pow(Math.abs((Integer)right)));
-            }
-            return new BigDecimal((Integer)left).pow((Integer)right).intValue();
+        String type = ArithmeticUtil.determineClassTypeForArithmetic(left, right);
+        Object returnValue = null;
+
+        switch(type) {
+            case "Integer":
+                returnValue = calculateIntegerPower(left, right);
+                break;
+            case "Long":
+                returnValue = calculateLongPower(left, right);
+                break;
+            case "BigDecimal":
+                returnValue = calculateDecimalPower(left, right);
+                break;
         }
 
-        if (left instanceof Long) {
-            if ((Long) right < 0) {
-                return new BigDecimal(1).divide(new BigDecimal((Long) left).pow(Math.abs((Integer) right)));
-            }
-
-            return new BigDecimal((Long) left).pow((Integer) ((Long) right).intValue()).longValue();
+        if (returnValue != null) {
+            return returnValue;
         }
 
-        if (left instanceof BigDecimal) {
-            return Value.verifyPrecision(new BigDecimal(Math.pow((((BigDecimal)left).doubleValue()), ((BigDecimal)right).doubleValue())), null);
-        }
 
         throw new InvalidOperatorArgument(
                 "Power(Integer, Integer), Power(Long, Long) or Power(Decimal, Decimal)",
                 String.format("Power(%s, %s)", left.getClass().getName(), right.getClass().getName())
         );
     }
+
+    private static Object calculateIntegerPower(Object left, Object right) {
+        if(!(left instanceof Integer)) {
+            left = ToIntegerEvaluator.toInteger(left);
+        }
+        if(!(right instanceof Integer)) {
+            right = ToIntegerEvaluator.toInteger(right);
+        }
+
+        if ((Integer) right < 0) {
+            return new BigDecimal(1).divide(new BigDecimal((Integer) left).pow(Math.abs((Integer) right)));
+        }
+        return new BigDecimal((Integer) left).pow((Integer) right).intValue();
+    }
+
+    private static Object calculateLongPower(Object left, Object right) {
+        if(!(left instanceof Long)) {
+            left = ToLongEvaluator.toLong(left);
+        }
+        if(!(right instanceof Long)) {
+            right = ToLongEvaluator.toLong(right);
+        }
+        if ((Long) right < 0) {
+            return new BigDecimal(1).divide(new BigDecimal((Long) left).pow(Math.abs((Integer) right)));
+        }
+        return new BigDecimal((Long) left).pow((Integer) ((Long) right).intValue()).longValue();
+    }
+
+    private static BigDecimal calculateDecimalPower(Object left, Object right) {
+        if(!(left instanceof BigDecimal)) {
+            left = ToDecimalEvaluator.toDecimal(left);
+        }
+        if(!(right instanceof BigDecimal)) {
+            right = ToDecimalEvaluator.toDecimal(right);
+        }
+        return Value.verifyPrecision(new BigDecimal(Math.pow((((BigDecimal) left).doubleValue()), ((BigDecimal) right).doubleValue())), null);
+    }
+
+
 
     @Override
     protected Object internalEvaluate(Context context) {

--- a/engine/src/main/java/org/opencds/cqf/cql/engine/elm/execution/ToLongEvaluator.java
+++ b/engine/src/main/java/org/opencds/cqf/cql/engine/elm/execution/ToLongEvaluator.java
@@ -28,7 +28,7 @@ public class ToLongEvaluator extends org.cqframework.cql.elm.execution.ToLong {
         }
 
         if (operand instanceof Integer) {
-            return (Long)operand;
+            return Long.valueOf((Integer)operand);
         }
 
         if (operand instanceof String) {

--- a/engine/src/test/java/org/opencds/cqf/cql/engine/execution/CqlArithmeticFunctionsTest.java
+++ b/engine/src/test/java/org/opencds/cqf/cql/engine/execution/CqlArithmeticFunctionsTest.java
@@ -869,4 +869,29 @@ public class CqlArithmeticFunctionsTest extends CqlExecutionTestBase {
         result = context.resolveExpressionRef("TruncatedDivide10By0DQuantity").getExpression().evaluate(context);
         assertThat(result, nullValue());
     }
+
+    /**
+     * Test some complex arithmetic expressions.
+     */
+    @Test
+    public void testComplexArithmetic() {
+
+        Context context = new Context(library);
+        Object result;
+
+        result = context.resolveExpressionRef("ComplexArithmetic2Pow10Minus8Decimal").getExpression().evaluate(context);
+        assertThat((BigDecimal)result, comparesEqualTo(new BigDecimal("2E-8")));
+
+        result = context.resolveExpressionRef("ComplexArithmetic2Pow10DMinus8Decimal").getExpression().evaluate(context);
+        assertThat((BigDecimal)result, comparesEqualTo(new BigDecimal("2E-8")));
+
+        result = context.resolveExpressionRef("ComplexArithmetic2DPow10DMinus8Decimal").getExpression().evaluate(context);
+        assertThat((BigDecimal)result, comparesEqualTo(new BigDecimal("2E-8")));
+
+        result = context.resolveExpressionRef("ComplexArithmetic2DPow10By4Integer").getExpression().evaluate(context);
+        assertThat(result, is(20000));
+
+        result = context.resolveExpressionRef("ComplexArithmetic2DPow10By4Long").getExpression().evaluate(context);
+        assertThat(result, is(20000L));
+    }
 }

--- a/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/CqlArithmeticFunctionsTest.cql
+++ b/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/CqlArithmeticFunctionsTest.cql
@@ -251,3 +251,12 @@ define TruncatedDivide10By5D: 10 div 5.0
 define TruncatedDivide10By5DQuantity: 10.0 'g' div 5.0 'g'
 define TruncatedDivide414By206DQuantity: 4.14 'm' div 2.06 'm'
 define TruncatedDivide10By0DQuantity: 10.0 'g' div 0.0 'g'
+
+
+//Complex Arithmetic
+
+define ComplexArithmetic2Pow10Minus8Decimal: 2*Power(10,-8)
+define ComplexArithmetic2Pow10DMinus8Decimal: 2*Power(10.0,-8)
+define ComplexArithmetic2DPow10DMinus8Decimal: 2.0*Power(10.0,-8)
+define ComplexArithmetic2DPow10By4Integer: 2*Power(10,4)
+define ComplexArithmetic2DPow10By4Long: 2L*Power(10,4)


### PR DESCRIPTION
For issue: https://github.com/DBCG/cql_engine/issues/86
In different Arithmetic Evaluator there are statements like :
`if (left instanceof Long) {
        return (Long) left * (Long) right;
    }`
or
`if (left instanceof BigDecimal) {
            return Value.verifyPrecision(new BigDecimal(Math.pow((((BigDecimal)left).doubleValue()), ((BigDecimal)right).doubleValue())), null);`

The right operand is being predicted as same type. It is true for single arithmetic expression. But for complex arithmetic expression it is not always true. Thus it is good to check both operand and the determine the resulting type and convert the operand which one is of different type. 
I have changed it for multiply and power. If the approach is considered good, I am going to apply same logic to other arithmetic evaluator like subtract, add, divide etc.