### PR TITLE
Fix proper includes

### DIFF
--- a/engine/src/main/java/org/opencds/cqf/cql/engine/elm/execution/ProperlyIncludesEvaluator.java
+++ b/engine/src/main/java/org/opencds/cqf/cql/engine/elm/execution/ProperlyIncludesEvaluator.java
@@ -101,7 +101,7 @@ public class ProperlyIncludesEvaluator extends org.cqframework.cql.elm.execution
 
         return AndEvaluator.and(
                 IncludedInEvaluator.listIncludedIn(right, left),
-                NotEqualEvaluator.notEqual(
+                GreaterEvaluator.greater(
                         leftCount,
                         (int) StreamSupport.stream(((Iterable<?>) right).spliterator(), false).count()
                 )

--- a/engine/src/test/java/org/opencds/cqf/cql/engine/execution/CqlListOperatorsTest.java
+++ b/engine/src/test/java/org/opencds/cqf/cql/engine/execution/CqlListOperatorsTest.java
@@ -708,6 +708,9 @@ public class CqlListOperatorsTest extends CqlExecutionTestBase {
 
         result = context.resolveExpressionRef("ProperlyIncludesNullLeft").getExpression().evaluate(context);
         assertThat(result, is(false));
+
+        result = context.resolveExpressionRef("ProperlyIncludes1And111").getExpression().evaluate(context);
+        assertThat(result, is(false));
     }
 
     /**
@@ -784,7 +787,10 @@ public class CqlListOperatorsTest extends CqlExecutionTestBase {
         result = context.resolveExpressionRef("ProperIncludedInTimeFalse").getExpression().evaluate(context);
         assertThat(result, is(false));
 
-        result = context.resolveExpressionRef("ProperlyIncludedInNulRight").getExpression().evaluate(context);
+        result = context.resolveExpressionRef("ProperlyIncludedInNullRight").getExpression().evaluate(context);
+        assertThat(result, is(false));
+
+        result = context.resolveExpressionRef("ProperlyIncludedIn11And1").getExpression().evaluate(context);
         assertThat(result, is(false));
     }
 

--- a/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/CqlListOperatorsTest.cql
+++ b/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/CqlListOperatorsTest.cql
@@ -204,7 +204,8 @@ define ProperIncludesDateTimeTrue:        {DateTime(2001, 9, 11), DateTime(2012,
 define ProperIncludesDateTimeFalse:       {DateTime(2001, 9, 11), DateTime(2012, 5, 10), DateTime(2014, 12, 10)} properly includes {DateTime(2001, 9, 11), DateTime(2012, 5, 10), DateTime(2014, 12, 10)}
 define ProperIncludesTimeTrue:            { @T15:59:59.999, @T20:59:59.999, @T20:59:49.999 } properly includes { @T15:59:59.999, @T20:59:59.999 }
 define ProperIncludesTimeFalse:           { @T15:59:59.999, @T20:59:59.999, @T20:59:49.999 } properly includes { @T15:59:59.999, @T20:59:59.999, @T14:59:22.999 }
-define ProperlyIncludesNullLeft: null properly includes {2}
+define ProperlyIncludesNullLeft:          null properly includes {2}
+define ProperlyIncludes1And111:           {1} properly includes {1, 1}
 
 //ProperContains
 define ProperContainsNullRightFalse: {'s', 'u', 'n'} properly includes null
@@ -219,16 +220,17 @@ define ProperInTimeTrue: @T15:59:59 properly included in { @T15:59:59, @T20:59:5
 define ProperInTimeNull: @T15:59:59 properly included in { @T15:59:59.999, @T20:59:59.999, @T20:59:49.999 }
 
 //ProperlyIncludedIn
-define ProperIncludedInEmptyAndEmpty: {} properly included in {}
+define ProperIncludedInEmptyAndEmpty:       {} properly included in {}
 define ProperIncludedInListNullAndListNull: {null} properly included in {null}
-define ProperIncludedInEmptyAnd123: {} properly included in {1, 2, 3}
-define ProperIncludedIn2And123: {2} properly included in {1, 2, 3}
-define ProperIncludedIn4And123: {4} properly included in {1, 2, 3}
-define ProperIncludedInDateTimeTrue: {DateTime(2012, 5, 10), DateTime(2014, 12, 10)} properly included in {DateTime(2001, 9, 11), DateTime(2012, 5, 10), DateTime(2014, 12, 10)}
-define ProperIncludedInDateTimeFalse: {DateTime(2001, 9, 11), DateTime(2012, 5, 10), DateTime(2014, 12, 10)} properly included in {DateTime(2001, 9, 11), DateTime(2012, 5, 10), DateTime(2014, 12, 10)}
-define ProperIncludedInTimeTrue: { @T15:59:59.999, @T20:59:59.999 } properly included in { @T15:59:59.999, @T20:59:59.999, @T20:59:49.999 }
-define ProperIncludedInTimeFalse: { @T15:59:59.999, @T20:59:59.999, @T14:59:22.999 } properly included in { @T15:59:59.999, @T20:59:59.999, @T20:59:49.999 }
-define ProperlyIncludedInNulRight: {'s', 'u', 'n'} properly included in null
+define ProperIncludedInEmptyAnd123:         {} properly included in {1, 2, 3}
+define ProperIncludedIn2And123:             {2} properly included in {1, 2, 3}
+define ProperIncludedIn4And123:             {4} properly included in {1, 2, 3}
+define ProperIncludedInDateTimeTrue:        {DateTime(2012, 5, 10), DateTime(2014, 12, 10)} properly included in {DateTime(2001, 9, 11), DateTime(2012, 5, 10), DateTime(2014, 12, 10)}
+define ProperIncludedInDateTimeFalse:       {DateTime(2001, 9, 11), DateTime(2012, 5, 10), DateTime(2014, 12, 10)} properly included in {DateTime(2001, 9, 11), DateTime(2012, 5, 10), DateTime(2014, 12, 10)}
+define ProperIncludedInTimeTrue:            { @T15:59:59.999, @T20:59:59.999 } properly included in { @T15:59:59.999, @T20:59:59.999, @T20:59:49.999 }
+define ProperIncludedInTimeFalse:           { @T15:59:59.999, @T20:59:59.999, @T14:59:22.999 } properly included in { @T15:59:59.999, @T20:59:59.999, @T20:59:49.999 }
+define ProperlyIncludedInNullRight:         {'s', 'u', 'n'} properly included in null
+define ProperlyIncludedIn11And1:            {1, 1} properly included in {1}
 
 //SingletonFrom
 define SingletonFromEmpty: singleton from {}


### PR DESCRIPTION
Fixed an issue with proper includes not checking that the size of the containing list is larger than the included list.  Test cases are added for both "properly includes" and "properly included in", though they share the same common logic.