### PR TITLE
Fix decimal equivalence with trailing zeroes

### DIFF
--- a/engine/src/main/java/org/opencds/cqf/cql/engine/elm/execution/EquivalentEvaluator.java
+++ b/engine/src/main/java/org/opencds/cqf/cql/engine/elm/execution/EquivalentEvaluator.java
@@ -74,7 +74,7 @@ public class EquivalentEvaluator extends org.cqframework.cql.elm.execution.Equiv
             BigDecimal leftDecimal = Value.verifyPrecision((BigDecimal)left, 0);
             BigDecimal rightDecimal = Value.verifyPrecision((BigDecimal)right, 0);
             int minScale = Math.min(leftDecimal.scale(), rightDecimal.scale());
-            if (minScale > 0) {
+            if (minScale >= 0) {
                 return leftDecimal.setScale(minScale, RoundingMode.FLOOR).compareTo(rightDecimal.setScale(minScale, RoundingMode.FLOOR)) == 0;
             }
             return leftDecimal.compareTo(rightDecimal) == 0;

--- a/engine/src/test/java/org/opencds/cqf/cql/engine/execution/CqlComparisonOperatorsTest.java
+++ b/engine/src/test/java/org/opencds/cqf/cql/engine/execution/CqlComparisonOperatorsTest.java
@@ -571,6 +571,9 @@ public class CqlComparisonOperatorsTest extends CqlExecutionTestBase {
         result = context.resolveExpressionRef("EquivFloat1Float1WithPrecisionAndZ").getExpression().evaluate(context);
         assertThat(result, is(true));
 
+        result = context.resolveExpressionRef("EquivFloatTrailingZero").getExpression().evaluate(context);
+        assertThat(result, is(true));
+
         result = context.resolveExpressionRef("EquivFloat1Int1").getExpression().evaluate(context);
         assertThat(result, is(true));
 

--- a/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/CqlComparisonOperatorsTest.cql
+++ b/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/CqlComparisonOperatorsTest.cql
@@ -159,39 +159,40 @@ define UncertaintyLessEqualTrue: DateTime(2013) <= DateTime(2014, 2, 15)
 define UncertaintyLessEqualFalse: DateTime(2015) <= DateTime(2014, 2, 15)
 
 //Equivalent
-define EquivTrueTrue                : true ~ true
-define EquivTrueFalse               : true ~ false
-define EquivFalseFalse              : false ~ false
-define EquivFalseTrue               : false ~ true
-define EquivNullNull                : null as String ~ null
-define EquivTrueNull                : true ~ null
-define EquivNullTrue                : null ~ true
-define EquivInt1Int1                : 1 ~ 1
-define EquivInt1Int2                : 1 ~ 2
-define EquivStringAStringA          : 'a' ~ 'a'
-define EquivStringAStringB          : 'a' ~ 'b'
-define EquivStringIgnoreCase        : 'Abel' ~ 'abel'
-define EquivFloat1Float1            : 1.0 ~ 1.0
-define EquivFloat1Float2            : 1.0 ~ 2.0
-define EquivFloat1Float1WithZ       : 1.0 ~ 1.00
-define EquivFloat1Float1WithPrecision : 1.5 ~ 1.55
+define EquivTrueTrue                      : true ~ true
+define EquivTrueFalse                     : true ~ false
+define EquivFalseFalse                    : false ~ false
+define EquivFalseTrue                     : false ~ true
+define EquivNullNull                      : null as String ~ null
+define EquivTrueNull                      : true ~ null
+define EquivNullTrue                      : null ~ true
+define EquivInt1Int1                      : 1 ~ 1
+define EquivInt1Int2                      : 1 ~ 2
+define EquivStringAStringA                : 'a' ~ 'a'
+define EquivStringAStringB                : 'a' ~ 'b'
+define EquivStringIgnoreCase              : 'Abel' ~ 'abel'
+define EquivFloat1Float1                  : 1.0 ~ 1.0
+define EquivFloat1Float2                  : 1.0 ~ 2.0
+define EquivFloat1Float1WithZ             : 1.0 ~ 1.00
+define EquivFloat1Float1WithPrecision     : 1.5 ~ 1.55
 define EquivFloat1Float1WithPrecisionAndZ : 1.50 ~ 1.55
-define EquivFloat1Int1              : 1.0 ~ 1
-define EquivFloat1Int2              : 1.0 ~ 2
-define EquivEqCM1CM1                : 1'cm' ~ 1'cm'
-define EquivEqCM1M01                : 1'cm' ~ 0.01'm'
-define RatioEquivalent              : 1'cm':2'cm' ~ 1'cm':2'cm'
-define RatioNotEquivalent           : 1'cm':2'cm' ~ 1.1'cm':2'cm'
-define EquivTupleJohnJohn           : Tuple { Id : 1, Name : 'John' } ~ Tuple { Id : 1, Name : 'John' }
-define EquivTupleJohnJohnWithNulls  : Tuple { Id : 1, Name : 'John', Position: null } ~ Tuple { Id : 1, Name : 'John', Position: null }
-define EquivTupleJohnJohnFalse      : Tuple { Id : 1, Name : 'John', Position: 'Shift Manager' } ~ Tuple { Id : 1, Name : 'John' }
-define EquivTupleJohnJohnFalse2     : Tuple { Id : 1, Name : 'John' } ~ Tuple { Id : 1, Name : 'John', Position: 'Shift Manager' }
-define EquivTupleJohnJane           : Tuple { Id : 1, Name : 'John' } ~ Tuple { Id : 2, Name : 'Jane' }
-define EquivTupleJohn1John2         : Tuple { Id : 1, Name : 'John' } ~ Tuple { Id : 2, Name : 'John' }
-define EquivDateTimeTodayToday      : Today() ~ Today()
-define EquivDateTimeTodayYesterday  : Today() ~ Today() - 1 days
-define EquivTime10A10A              : @T10:00:00.000 ~ @T10:00:00.000
-define EquivTime10A10P              : @T10:00:00.000 ~ @T22:00:00.000
+define EquivFloatTrailingZero             : 1.001 ~ 1.000
+define EquivFloat1Int1                    : 1.0 ~ 1
+define EquivFloat1Int2                    : 1.0 ~ 2
+define EquivEqCM1CM1                      : 1'cm' ~ 1'cm'
+define EquivEqCM1M01                      : 1'cm' ~ 0.01'm'
+define RatioEquivalent                    : 1'cm':2'cm' ~ 1'cm':2'cm'
+define RatioNotEquivalent                 : 1'cm':2'cm' ~ 1'cm':3'cm'
+define EquivTupleJohnJohn                 : Tuple { Id : 1, Name : 'John' } ~ Tuple { Id : 1, Name : 'John' }
+define EquivTupleJohnJohnWithNulls        : Tuple { Id : 1, Name : 'John', Position: null } ~ Tuple { Id : 1, Name : 'John', Position: null }
+define EquivTupleJohnJohnFalse            : Tuple { Id : 1, Name : 'John', Position: 'Shift Manager' } ~ Tuple { Id : 1, Name : 'John' }
+define EquivTupleJohnJohnFalse2           : Tuple { Id : 1, Name : 'John' } ~ Tuple { Id : 1, Name : 'John', Position: 'Shift Manager' }
+define EquivTupleJohnJane                 : Tuple { Id : 1, Name : 'John' } ~ Tuple { Id : 2, Name : 'Jane' }
+define EquivTupleJohn1John2               : Tuple { Id : 1, Name : 'John' } ~ Tuple { Id : 2, Name : 'John' }
+define EquivDateTimeTodayToday            : Today() ~ Today()
+define EquivDateTimeTodayYesterday        : Today() ~ Today() - 1 days
+define EquivTime10A10A                    : @T10:00:00.000 ~ @T10:00:00.000
+define EquivTime10A10P                    : @T10:00:00.000 ~ @T22:00:00.000
 
 //Not Equal
 define SimpleNotEqTrueTrue : true != true


### PR DESCRIPTION
In the [Equivalent logical specification](https://cql.hl7.org/04-logicalspecification.html#equivalent), it mentions that "[f]or decimals, equivalent means the values are the same with the comparison done on values rounded to the precision of the least precise operand; trailing zeroes after the decimal are ignored in determining precision for equivalent comparison."  Would the correct reading of this be that, for `1.001 ~ 1.000`:
- The trailing zeroes of `1.000` are ignored in determining precision, so it is treated as `1` with precision 0
- `1.001` has three digits of precision and `1` has 0, so the comparison is done with the values rounded to the lower precision (0)
- Truncating `1.001` to precision 0 yields `1`, and `1 ~ 1 == true`, so the expression evaluates to `true`

If so, I added this as a test case and have a proposed fix in the `EquivalentEvaluator`.  Otherwise, please let me know if I'm reading this the wrong way or misunderstanding!