### PR TITLE
Remove library overloads for CodeSystem and ValueSet resolution

### DIFF
--- a/engine.fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/searchparam/SearchParameterResolver.java
+++ b/engine.fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/searchparam/SearchParameterResolver.java
@@ -8,7 +8,6 @@ import java.util.Set;
 import org.apache.commons.lang3.tuple.Pair;
 
 import ca.uhn.fhir.context.FhirContext;
-import ca.uhn.fhir.context.FhirVersionEnum;
 import ca.uhn.fhir.context.RuntimeSearchParam;
 import ca.uhn.fhir.model.api.IQueryParameterType;
 import ca.uhn.fhir.rest.api.RestSearchParameterTypeEnum;

--- a/engine.fhir/src/test/java/org/hl7/fhirpath/TestFhirPath.java
+++ b/engine.fhir/src/test/java/org/hl7/fhirpath/TestFhirPath.java
@@ -21,8 +21,6 @@ import java.util.TimeZone;
 
 import javax.xml.bind.JAXB;
 
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
-
 import org.cqframework.cql.cql2elm.CqlTranslator;
 import org.cqframework.cql.cql2elm.CqlTranslatorException;
 import org.cqframework.cql.cql2elm.FhirLibrarySourceProvider;
@@ -175,7 +173,7 @@ public class TestFhirPath {
         options.add(CqlTranslator.Options.EnableDateRangeOptimization);
         UcumService ucumService = new UcumEssenceService(
                 UcumEssenceService.class.getResourceAsStream("/ucum-essence.xml"));
-        
+
         CqlTranslator translator = CqlTranslator.fromText(cql, getModelManager(), getLibraryManager(), ucumService,
                 options.toArray(new CqlTranslator.Options[options.size()]));
         if (translator.getErrors().size() > 0) {

--- a/engine.fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/data/FhirExecutionTestBase.java
+++ b/engine.fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/data/FhirExecutionTestBase.java
@@ -11,8 +11,6 @@ import java.util.Map;
 
 import javax.xml.bind.JAXBException;
 
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
-
 import org.cqframework.cql.cql2elm.*;
 import org.cqframework.cql.cql2elm.model.TranslatedLibrary;
 import org.cqframework.cql.elm.execution.Library;

--- a/engine.jaxb/src/main/java/org/opencds/cqf/cql/engine/elm/execution/ObjectFactoryEx.java
+++ b/engine.jaxb/src/main/java/org/opencds/cqf/cql/engine/elm/execution/ObjectFactoryEx.java
@@ -6,7 +6,6 @@ import javax.xml.bind.annotation.XmlRegistry;
 import javax.xml.namespace.QName;
 
 import org.cqframework.cql.elm.execution.*;
-import org.opencds.cqf.cql.engine.elm.execution.*;
 
 @XmlRegistry
 public class ObjectFactoryEx extends org.cqframework.cql.elm.execution.ObjectFactory {

--- a/engine/src/main/java/org/opencds/cqf/cql/engine/data/SystemDataProvider.java
+++ b/engine/src/main/java/org/opencds/cqf/cql/engine/data/SystemDataProvider.java
@@ -159,8 +159,7 @@ public class SystemDataProvider extends BaseModelResolver implements DataProvide
     public Object createInstance(String typeName) {
         Class<?> clazz = resolveType(typeName);
         try {
-            Object object = clazz.getDeclaredConstructor().newInstance();
-            return object;
+            return clazz.getDeclaredConstructor().newInstance();
         } catch (InstantiationException | InvocationTargetException |
             ExceptionInInitializerError | IllegalAccessException | SecurityException | NoSuchMethodException e) {
             throw new IllegalArgumentException(String.format("Could not create an instance of class %s.", clazz.getName()));

--- a/engine/src/main/java/org/opencds/cqf/cql/engine/elm/execution/AnyInCodeSystemEvaluator.java
+++ b/engine/src/main/java/org/opencds/cqf/cql/engine/elm/execution/AnyInCodeSystemEvaluator.java
@@ -1,6 +1,5 @@
 package org.opencds.cqf.cql.engine.elm.execution;
 
-import org.cqframework.cql.elm.execution.Expression;
 import org.opencds.cqf.cql.engine.execution.Context;
 
 public class AnyInCodeSystemEvaluator extends org.cqframework.cql.elm.execution.AnyInCodeSystem {

--- a/engine/src/main/java/org/opencds/cqf/cql/engine/elm/execution/AnyInValueSetEvaluator.java
+++ b/engine/src/main/java/org/opencds/cqf/cql/engine/elm/execution/AnyInValueSetEvaluator.java
@@ -1,6 +1,5 @@
 package org.opencds.cqf.cql.engine.elm.execution;
 
-import org.cqframework.cql.elm.execution.Expression;
 import org.opencds.cqf.cql.engine.execution.Context;
 
 public class AnyInValueSetEvaluator extends org.cqframework.cql.elm.execution.AnyInValueSet

--- a/engine/src/main/java/org/opencds/cqf/cql/engine/elm/execution/CodeSystemRefEvaluator.java
+++ b/engine/src/main/java/org/opencds/cqf/cql/engine/elm/execution/CodeSystemRefEvaluator.java
@@ -10,8 +10,13 @@ import org.opencds.cqf.cql.engine.runtime.CodeSystem;
 public class CodeSystemRefEvaluator extends org.cqframework.cql.elm.execution.CodeSystemRef {
 
     public static CodeSystem toCodeSystem(Context context, CodeSystemRef csr) {
-        CodeSystemDef csd = context.resolveCodeSystemRef(csr.getLibraryName(), csr.getName());
-        return new CodeSystem().withId(csd.getId()).withVersion(csd.getVersion()).withName(csd.getName());
+        boolean enteredLibrary = context.enterLibrary(csr.getLibraryName());
+        try {
+            CodeSystemDef csd = context.resolveCodeSystemRef(csr.getName());
+            return new CodeSystem().withId(csd.getId()).withVersion(csd.getVersion()).withName(csd.getName());
+        } finally {
+            context.exitLibrary(enteredLibrary);
+        }
     }
 
     @Override

--- a/engine/src/main/java/org/opencds/cqf/cql/engine/elm/execution/ConceptRefEvaluator.java
+++ b/engine/src/main/java/org/opencds/cqf/cql/engine/elm/execution/ConceptRefEvaluator.java
@@ -1,6 +1,5 @@
 package org.opencds.cqf.cql.engine.elm.execution;
 
-import org.cqframework.cql.elm.execution.CodeDef;
 import org.cqframework.cql.elm.execution.CodeRef;
 import org.cqframework.cql.elm.execution.ConceptDef;
 import org.cqframework.cql.elm.execution.ConceptRef;
@@ -10,7 +9,6 @@ import org.opencds.cqf.cql.engine.runtime.Concept;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 public class ConceptRefEvaluator extends org.cqframework.cql.elm.execution.ConceptRef {
 

--- a/engine/src/main/java/org/opencds/cqf/cql/engine/elm/execution/ExpandValueSetEvaluator.java
+++ b/engine/src/main/java/org/opencds/cqf/cql/engine/elm/execution/ExpandValueSetEvaluator.java
@@ -1,15 +1,8 @@
 package org.opencds.cqf.cql.engine.elm.execution;
 
-import org.cqframework.cql.elm.execution.CodeSystemDef;
-import org.cqframework.cql.elm.execution.CodeSystemRef;
-import org.cqframework.cql.elm.execution.ValueSetDef;
-import org.cqframework.cql.elm.execution.ValueSetRef;
 import org.opencds.cqf.cql.engine.exception.InvalidOperatorArgument;
 import org.opencds.cqf.cql.engine.execution.Context;
-import org.opencds.cqf.cql.engine.runtime.Code;
-import org.opencds.cqf.cql.engine.runtime.Concept;
 import org.opencds.cqf.cql.engine.runtime.ValueSet;
-import org.opencds.cqf.cql.engine.terminology.CodeSystemInfo;
 import org.opencds.cqf.cql.engine.terminology.TerminologyProvider;
 import org.opencds.cqf.cql.engine.terminology.ValueSetInfo;
 
@@ -33,7 +26,7 @@ public class ExpandValueSetEvaluator extends org.cqframework.cql.elm.execution.E
 
         throw new InvalidOperatorArgument(
             "ExpandValueSet(ValueSet)",
-            String.format("ExpandValueSet(%s, %s)", valueset.getClass().getName())
+            String.format("ExpandValueSet(%s)", valueset.getClass().getName())
         );
     }
 

--- a/engine/src/main/java/org/opencds/cqf/cql/engine/elm/execution/InCodeSystemEvaluator.java
+++ b/engine/src/main/java/org/opencds/cqf/cql/engine/elm/execution/InCodeSystemEvaluator.java
@@ -1,8 +1,5 @@
 package org.opencds.cqf.cql.engine.elm.execution;
 
-import org.cqframework.cql.elm.execution.CodeSystemDef;
-import org.cqframework.cql.elm.execution.CodeSystemRef;
-import org.cqframework.cql.elm.execution.Expression;
 import org.opencds.cqf.cql.engine.exception.InvalidOperatorArgument;
 import org.opencds.cqf.cql.engine.execution.Context;
 import org.opencds.cqf.cql.engine.runtime.Code;

--- a/engine/src/main/java/org/opencds/cqf/cql/engine/elm/execution/InValueSetEvaluator.java
+++ b/engine/src/main/java/org/opencds/cqf/cql/engine/elm/execution/InValueSetEvaluator.java
@@ -1,12 +1,10 @@
 package org.opencds.cqf.cql.engine.elm.execution;
 
-import org.cqframework.cql.elm.execution.*;
 import org.opencds.cqf.cql.engine.exception.InvalidOperatorArgument;
 import org.opencds.cqf.cql.engine.execution.Context;
 import org.opencds.cqf.cql.engine.runtime.Code;
 import org.opencds.cqf.cql.engine.runtime.Concept;
 import org.opencds.cqf.cql.engine.runtime.ValueSet;
-import org.opencds.cqf.cql.engine.terminology.CodeSystemInfo;
 import org.opencds.cqf.cql.engine.terminology.TerminologyProvider;
 import org.opencds.cqf.cql.engine.terminology.ValueSetInfo;
 

--- a/engine/src/main/java/org/opencds/cqf/cql/engine/elm/execution/RetrieveEvaluator.java
+++ b/engine/src/main/java/org/opencds/cqf/cql/engine/elm/execution/RetrieveEvaluator.java
@@ -12,6 +12,7 @@ import org.opencds.cqf.cql.engine.execution.Context;
 import org.opencds.cqf.cql.engine.runtime.Code;
 import org.opencds.cqf.cql.engine.runtime.Concept;
 import org.opencds.cqf.cql.engine.runtime.Interval;
+import org.opencds.cqf.cql.engine.runtime.ValueSet;
 
 public class RetrieveEvaluator extends org.cqframework.cql.elm.execution.Retrieve {
 
@@ -22,52 +23,44 @@ public class RetrieveEvaluator extends org.cqframework.cql.elm.execution.Retriev
         Iterable<Code> codes = null;
         String valueSet = null;
         if (this.getCodes() != null) {
-            if (this.getCodes() instanceof ValueSetRef) {
-                ValueSetRef valueSetRef = (ValueSetRef)this.getCodes();
-                ValueSetDef valueSetDef = context.resolveValueSetRef(valueSetRef.getLibraryName(), valueSetRef.getName());
-                // TODO: Handle value set versions.....
-                valueSet = valueSetDef.getId();
-            }
-            else {
-                Object codesResult = this.getCodes().evaluate(context);
-                if (codesResult instanceof String) {
-                    List<Code> codesList = new ArrayList<>();
-                    codesList.add(new Code().withCode((String)codesResult));
-                    codes = codesList;
+            Object codesResult = this.getCodes().evaluate(context);
+            if (codesResult instanceof ValueSet) {
+                valueSet = ((ValueSet)codesResult).getId();
+            } else if (codesResult instanceof String) {
+                List<Code> codesList = new ArrayList<>();
+                codesList.add(new Code().withCode((String) codesResult));
+                codes = codesList;
+            } else if (codesResult instanceof Code) {
+                List<Code> codesList = new ArrayList<>();
+                codesList.add((Code) codesResult);
+                codes = codesList;
+            } else if (codesResult instanceof Concept) {
+                List<Code> codesList = new ArrayList<>();
+                for (Code conceptCode : ((Concept) codesResult).getCodes()) {
+                    codesList.add(conceptCode);
                 }
-                else if (codesResult instanceof Code) {
-                    List<Code> codesList = new ArrayList<>();
-                    codesList.add((Code)codesResult);
-                    codes = codesList;
-                }
-                else if (codesResult instanceof Concept) {
-                    List<Code> codesList = new ArrayList<>();
-                    for (Code conceptCode : ((Concept)codesResult).getCodes()) {
-                        codesList.add(conceptCode);
-                    }
-                    codes = codesList;
-                }
-                else {
-                    codes = (Iterable<Code>) codesResult;
-                }
+                codes = codesList;
+            } else {
+                codes = (Iterable<Code>) codesResult;
             }
         }
         Interval dateRange = null;
         if (this.getDateRange() != null) {
-            dateRange = (Interval)this.getDateRange().evaluate(context);
+            dateRange = (Interval) this.getDateRange().evaluate(context);
         }
 
-		Object result = dataProvider.retrieve(context.getCurrentContext(), (String)dataProvider.getContextPath(context.getCurrentContext(), dataType.getLocalPart()),
-				context.getCurrentContextValue(), dataType.getLocalPart(), getTemplateId(),
-                getCodeProperty(), codes, valueSet, getDateProperty(), getDateLowProperty(), getDateHighProperty(), dateRange);
+        Object result = dataProvider.retrieve(context.getCurrentContext(),
+                (String) dataProvider.getContextPath(context.getCurrentContext(), dataType.getLocalPart()),
+                context.getCurrentContextValue(), dataType.getLocalPart(), getTemplateId(),
+                getCodeProperty(), codes, valueSet, getDateProperty(), getDateLowProperty(), getDateHighProperty(),
+                dateRange);
 
-        //append list results to evaluatedResources list
+        // append list results to evaluatedResources list
         if (result instanceof List) {
-            for (Object element : (List<?>)result) {
+            for (Object element : (List<?>) result) {
                 context.getEvaluatedResources().add(element);
             }
-        }
-        else {
+        } else {
             context.getEvaluatedResources().add(result);
         }
 

--- a/engine/src/main/java/org/opencds/cqf/cql/engine/elm/execution/RetrieveEvaluator.java
+++ b/engine/src/main/java/org/opencds/cqf/cql/engine/elm/execution/RetrieveEvaluator.java
@@ -5,7 +5,6 @@ import java.util.List;
 
 import javax.xml.namespace.QName;
 
-import org.cqframework.cql.elm.execution.ValueSetDef;
 import org.cqframework.cql.elm.execution.ValueSetRef;
 import org.opencds.cqf.cql.engine.data.DataProvider;
 import org.opencds.cqf.cql.engine.execution.Context;
@@ -23,25 +22,31 @@ public class RetrieveEvaluator extends org.cqframework.cql.elm.execution.Retriev
         Iterable<Code> codes = null;
         String valueSet = null;
         if (this.getCodes() != null) {
-            Object codesResult = this.getCodes().evaluate(context);
-            if (codesResult instanceof ValueSet) {
-                valueSet = ((ValueSet)codesResult).getId();
-            } else if (codesResult instanceof String) {
-                List<Code> codesList = new ArrayList<>();
-                codesList.add(new Code().withCode((String) codesResult));
-                codes = codesList;
-            } else if (codesResult instanceof Code) {
-                List<Code> codesList = new ArrayList<>();
-                codesList.add((Code) codesResult);
-                codes = codesList;
-            } else if (codesResult instanceof Concept) {
-                List<Code> codesList = new ArrayList<>();
-                for (Code conceptCode : ((Concept) codesResult).getCodes()) {
-                    codesList.add(conceptCode);
+            if (this.getCodes() instanceof ValueSetRef) {
+                ValueSet vs = ValueSetRefEvaluator.toValueSet(context, (ValueSetRef)this.getCodes());
+                valueSet = vs.getId();
+            }
+            else {
+                Object codesResult = this.getCodes().evaluate(context);
+                if (codesResult instanceof ValueSet) {
+                    valueSet = ((ValueSet)codesResult).getId();
+                } else if (codesResult instanceof String) {
+                    List<Code> codesList = new ArrayList<>();
+                    codesList.add(new Code().withCode((String) codesResult));
+                    codes = codesList;
+                } else if (codesResult instanceof Code) {
+                    List<Code> codesList = new ArrayList<>();
+                    codesList.add((Code) codesResult);
+                    codes = codesList;
+                } else if (codesResult instanceof Concept) {
+                    List<Code> codesList = new ArrayList<>();
+                    for (Code conceptCode : ((Concept) codesResult).getCodes()) {
+                        codesList.add(conceptCode);
+                    }
+                    codes = codesList;
+                } else {
+                    codes = (Iterable<Code>) codesResult;
                 }
-                codes = codesList;
-            } else {
-                codes = (Iterable<Code>) codesResult;
             }
         }
         Interval dateRange = null;

--- a/engine/src/main/java/org/opencds/cqf/cql/engine/elm/execution/ValueSetRefEvaluator.java
+++ b/engine/src/main/java/org/opencds/cqf/cql/engine/elm/execution/ValueSetRefEvaluator.java
@@ -7,7 +7,6 @@ import org.cqframework.cql.elm.execution.ValueSetRef;
 import org.opencds.cqf.cql.engine.execution.Context;
 import org.opencds.cqf.cql.engine.runtime.CodeSystem;
 import org.opencds.cqf.cql.engine.runtime.ValueSet;
-import org.opencds.cqf.cql.engine.terminology.CodeSystemInfo;
 import org.opencds.cqf.cql.engine.terminology.TerminologyProvider;
 import org.opencds.cqf.cql.engine.terminology.ValueSetInfo;
 
@@ -16,10 +15,10 @@ public class ValueSetRefEvaluator extends org.cqframework.cql.elm.execution.Valu
     public static ValueSet toValueSet(Context context, ValueSetRef vsr) {
         boolean enteredLibrary = context.enterLibrary(vsr.getLibraryName());
         try {
-            ValueSetDef vsd = context.resolveValueSetRef(vsr.getLibraryName(), vsr.getName());
+            ValueSetDef vsd = context.resolveValueSetRef(vsr.getName());
             ValueSet vs = new ValueSet().withId(vsd.getId()).withVersion(vsd.getVersion());
             for (CodeSystemRef csr : vsd.getCodeSystem()) {
-                CodeSystemDef csd = context.resolveCodeSystemRef(csr.getLibraryName(), csr.getName());
+                CodeSystemDef csd = context.resolveCodeSystemRef(csr.getName());
                 vs.addCodeSystem(new CodeSystem().withId(csd.getId()).withVersion(csd.getVersion()));
             }
             return vs;

--- a/engine/src/main/java/org/opencds/cqf/cql/engine/elm/execution/ValueSetRefEvaluator.java
+++ b/engine/src/main/java/org/opencds/cqf/cql/engine/elm/execution/ValueSetRefEvaluator.java
@@ -1,6 +1,5 @@
 package org.opencds.cqf.cql.engine.elm.execution;
 
-import org.cqframework.cql.elm.execution.CodeSystemDef;
 import org.cqframework.cql.elm.execution.CodeSystemRef;
 import org.cqframework.cql.elm.execution.ValueSetDef;
 import org.cqframework.cql.elm.execution.ValueSetRef;
@@ -18,8 +17,8 @@ public class ValueSetRefEvaluator extends org.cqframework.cql.elm.execution.Valu
             ValueSetDef vsd = context.resolveValueSetRef(vsr.getName());
             ValueSet vs = new ValueSet().withId(vsd.getId()).withVersion(vsd.getVersion());
             for (CodeSystemRef csr : vsd.getCodeSystem()) {
-                CodeSystemDef csd = context.resolveCodeSystemRef(csr.getName());
-                vs.addCodeSystem(new CodeSystem().withId(csd.getId()).withVersion(csd.getVersion()));
+                CodeSystem cs = CodeSystemRefEvaluator.toCodeSystem(context, csr);
+                vs.addCodeSystem(cs);
             }
             return vs;
         }

--- a/engine/src/main/java/org/opencds/cqf/cql/engine/execution/Context.java
+++ b/engine/src/main/java/org/opencds/cqf/cql/engine/execution/Context.java
@@ -656,16 +656,6 @@ public class Context {
                 name, getCurrentLibrary().getIdentifier().getId()));
     }
 
-    public ValueSetDef resolveValueSetRef(String libraryName, String name) {
-        boolean enteredLibrary = enterLibrary(libraryName);
-        try {
-            return resolveValueSetRef(name);
-        }
-        finally {
-            exitLibrary(enteredLibrary);
-        }
-    }
-
     public CodeSystemDef resolveCodeSystemRef(String name) {
         for (CodeSystemDef codeSystemDef : getCurrentLibrary().getCodeSystems().getDef()) {
             if (codeSystemDef.getName().equals(name)) {
@@ -675,16 +665,6 @@ public class Context {
 
         throw new CqlException(String.format("Could not resolve code system reference '%s' in library '%s'.",
                 name, getCurrentLibrary().getIdentifier().getId()));
-    }
-
-    public CodeSystemDef resolveCodeSystemRef(String libraryName, String name) {
-        boolean enteredLibrary = enterLibrary(libraryName);
-        try {
-            return resolveCodeSystemRef(name);
-        }
-        finally {
-            exitLibrary(enteredLibrary);
-        }
     }
 
     private Map<String, DataProvider> dataProviders = new HashMap<>();

--- a/engine/src/test/java/org/opencds/cqf/cql/engine/execution/CqlExecutionTestBase.java
+++ b/engine/src/test/java/org/opencds/cqf/cql/engine/execution/CqlExecutionTestBase.java
@@ -11,8 +11,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
-
 import org.cqframework.cql.cql2elm.CqlTranslator;
 import org.cqframework.cql.cql2elm.CqlTranslatorException;
 import org.cqframework.cql.cql2elm.LibraryManager;
@@ -63,7 +61,7 @@ public abstract class CqlExecutionTestBase {
                 options.add(CqlTranslator.Options.EnableAnnotations);
                 options.add(CqlTranslator.Options.EnableLocators);
 
-                CqlTranslator translator = CqlTranslator.fromFile(cqlFile, getModelManager(), getLibraryManager(), ucumService, 
+                CqlTranslator translator = CqlTranslator.fromFile(cqlFile, getModelManager(), getLibraryManager(), ucumService,
                     options.toArray(new CqlTranslator.Options[options.size()]));
 
                 if (translator.getErrors().size() > 0) {

--- a/engine/src/test/java/org/opencds/cqf/cql/engine/execution/CqlPerformanceIT.java
+++ b/engine/src/test/java/org/opencds/cqf/cql/engine/execution/CqlPerformanceIT.java
@@ -13,8 +13,6 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
-
 import org.cqframework.cql.cql2elm.CqlTranslator;
 import org.cqframework.cql.cql2elm.CqlTranslatorException;
 import org.cqframework.cql.cql2elm.LibraryManager;

--- a/engine/src/test/java/org/opencds/cqf/cql/engine/execution/CqlPerformanceIT.java
+++ b/engine/src/test/java/org/opencds/cqf/cql/engine/execution/CqlPerformanceIT.java
@@ -38,7 +38,7 @@ public class CqlPerformanceIT  extends TranslatingTestBase {
         Library library = this.toLibrary("library Test");
         LibraryLoader libraryLoader = new InMemoryLibraryLoader(Collections.singleton(library));
 
-        runPerformanceTest("Engine init", "Test", libraryLoader, 0.1);
+        runPerformanceTest("Engine init", "Test", libraryLoader, 0.2);
     }
 
     // This test is for the various CQL operators

--- a/engine/src/test/java/org/opencds/cqf/cql/engine/execution/CqlTestSuite.java
+++ b/engine/src/test/java/org/opencds/cqf/cql/engine/execution/CqlTestSuite.java
@@ -15,8 +15,6 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.TimeZone;
 
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
-
 import org.cqframework.cql.cql2elm.CqlTranslator;
 import org.cqframework.cql.cql2elm.CqlTranslatorException;
 import org.cqframework.cql.cql2elm.LibraryManager;

--- a/engine/src/test/java/org/opencds/cqf/cql/engine/execution/IncludedValueSetRefTest.java
+++ b/engine/src/test/java/org/opencds/cqf/cql/engine/execution/IncludedValueSetRefTest.java
@@ -1,0 +1,45 @@
+package org.opencds.cqf.cql.engine.execution;
+
+import org.opencds.cqf.cql.engine.runtime.Code;
+import org.opencds.cqf.cql.engine.terminology.CodeSystemInfo;
+import org.opencds.cqf.cql.engine.terminology.TerminologyProvider;
+import org.opencds.cqf.cql.engine.terminology.ValueSetInfo;
+import org.testng.annotations.Test;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+import java.util.Collections;
+import java.util.List;
+
+public class IncludedValueSetRefTest extends CqlExecutionTestBase {
+
+    @Test
+    public void testIncludedValueSetRef() {
+        Code expected = new Code().withCode("M").withSystem("http://test.com/system");
+
+        TerminologyProvider terminologyProvider = new TerminologyProvider() {
+            public boolean in(Code code, ValueSetInfo valueSet) {
+                return true;
+            }
+
+            public Iterable<Code> expand(ValueSetInfo valueSet) {
+                return Collections.singletonList(expected);
+            }
+
+            public Code lookup(Code code, CodeSystemInfo codeSystem) {
+                return null;
+            }
+
+        };
+        Context ctx = new Context(library);
+        ctx.registerLibraryLoader(new TestLibraryLoader(getLibraryManager()));
+        ctx.registerTerminologyProvider(terminologyProvider);
+
+        @SuppressWarnings("unchecked")
+        List<Code> actual = (List<Code>)ctx.resolveExpressionRef("IncludedValueSet").getExpression().evaluate(ctx);
+        assertNotNull(actual);
+        assertEquals(actual.size(), 1);
+
+        CqlConceptTest.assertEqual(expected, actual.get(0));
+    }
+}

--- a/engine/src/test/java/org/opencds/cqf/cql/engine/execution/TranslatingTestBase.java
+++ b/engine/src/test/java/org/opencds/cqf/cql/engine/execution/TranslatingTestBase.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.util.Map;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
@@ -54,7 +53,7 @@ public class TranslatingTestBase {
         mapper.configure(SerializationFeature.INDENT_OUTPUT, true);
         JaxbAnnotationModule annotationModule = new JaxbAnnotationModule();
         mapper.registerModule(annotationModule);
-        
+
         return mapper.writeValueAsString(wrapper);
     }
 

--- a/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/IncludedValueSetRefTest.cql
+++ b/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/IncludedValueSetRefTest.cql
@@ -1,0 +1,7 @@
+library IncludedValueSetRefTest
+
+include IncludedValueSetRefTestCommon called "Common"
+
+define "IncludedValueSet":
+    "Common"."Common"
+

--- a/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/IncludedValueSetRefTestCommon.cql
+++ b/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/IncludedValueSetRefTestCommon.cql
@@ -1,0 +1,3 @@
+library IncludedValueSetRefTestCommon
+
+valueset "Common" : 'http://test/common'


### PR DESCRIPTION
* Resolves cqframework/clinical_quality_language#893
* Removes overloads for codesystem and valueset resolution that manage the library stack
* Fixes retrieve evaluator to handle codes