### PR TITLE
Feature test cql  logical operators, string operations, conditional operators

### DIFF
--- a/engine.fhir/src/test/java/org/hl7/fhirpath/TestFhirPath.java
+++ b/engine.fhir/src/test/java/org/hl7/fhirpath/TestFhirPath.java
@@ -533,7 +533,7 @@ public class TestFhirPath {
 
     @Test
     public void testCqlConditionalOperators() {
-        runTests("cql/CqlConditionalOperatorsTest.xml", 9, 6, 0);
+        runTests("cql/CqlConditionalOperatorsTest.xml", 9, 9, 0);
     }
 
     @Test

--- a/engine.fhir/src/test/java/org/hl7/fhirpath/TestFhirPath.java
+++ b/engine.fhir/src/test/java/org/hl7/fhirpath/TestFhirPath.java
@@ -537,7 +537,7 @@ public class TestFhirPath {
 
     @Test
     public void testCqlDateTimeOperators() {
-        runTests("cql/CqlDateTimeOperatorsTest.xml", 294, 279, 0);
+        runTests("cql/CqlDateTimeOperatorsTest.xml", 294, 280, 0);
     }
 
     @Test
@@ -557,7 +557,7 @@ public class TestFhirPath {
 
     @Test
     public void testCqlLogicalOperators() {
-        runTests("cql/CqlLogicalOperatorsTest.xml", 39, 26, 0);
+        runTests("cql/CqlLogicalOperatorsTest.xml", 39, 39, 0);
     }
 
     @Test
@@ -577,7 +577,7 @@ public class TestFhirPath {
 
     @Test
     public void testCqlTypes() {
-        runTests("cql/CqlTypesTest.xml", 27, 22, 0);
+        runTests("cql/CqlTypesTest.xml", 27, 25, 0);
     }
 
     @Test

--- a/engine.fhir/src/test/java/org/hl7/fhirpath/TestFhirPath.java
+++ b/engine.fhir/src/test/java/org/hl7/fhirpath/TestFhirPath.java
@@ -567,7 +567,7 @@ public class TestFhirPath {
 
     @Test
     public void testCqlStringOperators() {
-        runTests("cql/CqlStringOperatorsTest.xml", 81, 78, 0);
+        runTests("cql/CqlStringOperatorsTest.xml", 81, 80, 0);
     }
 
     @Test

--- a/engine.fhir/src/test/resources/org/hl7/fhirpath/cql/CqlConditionalOperatorsTest.xml
+++ b/engine.fhir/src/test/resources/org/hl7/fhirpath/cql/CqlConditionalOperatorsTest.xml
@@ -3,15 +3,15 @@
 	name="CqlConditionalOperatorsTest" reference="https://cql.hl7.org/03-developersguide.html#conditional-expressions">
 	<group name="if-then-else">
 		<test name="IfTrue1">
-			<expression>if 10 &gt; 5 then 5 else 10</expression>
+			<expression>(if 10 &gt; 5 then 5 else 10)</expression>
 			<output>5</output>
 		</test>
 		<test name="IfFalse1">
-			<expression>if 10 = 5 then 10 + 5 else 10 - 5</expression>
+			<expression>(if 10 = 5 then 10 + 5 else 10 - 5)</expression>
 			<output>5</output>
 		</test>
 		<test name="IfNull1">
-			<expression>if 10 = null then 5 else 10</expression>
+			<expression>(if 10 = null then 5 else 10)</expression>
 			<output>10</output>
 		</test>
 	</group>
@@ -30,7 +30,7 @@
 			<expression>
 				case
 					when 5 &gt; 10 then 5 + 10
-					when 5 = 10 then 5
+					when 5 = 10 then 10
 					else 10 - 5
 				end
 			</expression>

--- a/engine.fhir/src/test/resources/org/hl7/fhirpath/cql/CqlLogicalOperatorsTest.xml
+++ b/engine.fhir/src/test/resources/org/hl7/fhirpath/cql/CqlLogicalOperatorsTest.xml
@@ -3,168 +3,168 @@
 	name="CqlLogicalOperatorsTest" reference="https://cql.hl7.org/09-b-cqlreference.html#logical-operators-3">
 	<group name="And">
 		<test name="TrueAndTrue">
-			<expression>true and true</expression>
+			<expression>(true and true)</expression>
 			<output>true</output>
 		</test>
 		<test name="TrueAndFalse">
-			<expression>true and false</expression>
+			<expression>(true and false)</expression>
 			<output>false</output>
 		</test>
 		<test name="TrueAndNull">
-			<expression>true and null</expression>
+			<expression>(true and null)</expression>
 			<output>null</output>
 		</test>
 		<test name="FalseAndTrue">
-			<expression>false and true</expression>
+			<expression>(false and true)</expression>
 			<output>false</output>
 		</test>
 		<test name="FalseAndFalse">
-			<expression>false and false</expression>
+			<expression>(false and false)</expression>
 			<output>false</output>
 		</test>
 		<test name="FalseAndNull">
-			<expression>false and null</expression>
+			<expression>(false and null)</expression>
 			<output>false</output>
 		</test>
 		<test name="NullAndTrue">
-			<expression>null and true</expression>
+			<expression>(null and true)</expression>
 			<output>null</output>
 		</test>
 		<test name="NullAndFalse">
-			<expression>null and false</expression>
+			<expression>(null and false)</expression>
 			<output>false</output>
 		</test>
 		<test name="NullAndNull">
-			<expression>null and null</expression>
+			<expression>(null and null)</expression>
 			<output>null</output>
 		</test>
 	</group>
 	<group name="Implies">
 		<!-- TODO: make Translator resolve Implies operator signatures -->
 		<test name="TrueImpliesTrue">
-			<expression>true implies true</expression>
+			<expression>(true implies true)</expression>
 			<output>true</output>
 		</test>
 		<test name="TrueImpliesFalse">
-			<expression>true implies false</expression>
+			<expression>(true implies false)</expression>
 			<output>false</output>
 		</test>
 		<test name="TrueImpliesNull">
-			<expression>true implies null</expression>
+			<expression>(true implies null)</expression>
 			<output>null</output>
 		</test>
 		<test name="FalseImpliesTrue">
-			<expression>false implies true</expression>
+			<expression>(false implies true)</expression>
 			<output>true</output>
 		</test>
 		<test name="FalseImpliesFalse">
-			<expression>false implies false</expression>
+			<expression>(false implies false)</expression>
 			<output>true</output>
 		</test>
 		<test name="FalseImpliesNull">
-			<expression>false implies null</expression>
+			<expression>(false implies null)</expression>
 			<output>true</output>
 		</test>
 		<test name="NullImpliesTrue">
-			<expression>null implies true</expression>
+			<expression>(null implies true)</expression>
 			<output>true</output>
 		</test>
 		<test name="NullImpliesFalse">
-			<expression>null implies false</expression>
+			<expression>(null implies false)</expression>
 			<output>null</output>
 		</test>
 		<test name="NullImpliesNull">
-			<expression>null implies null</expression>
+			<expression>(null implies null)</expression>
 			<output>null</output>
 		</test>
 	</group>
 	<group name="Not">
 		<test name="NotTrue">
-			<expression>not true</expression>
+			<expression>(not true)</expression>
 			<output>false</output>
 		</test>
 		<test name="NotFalse">
-			<expression>not false</expression>
+			<expression>(not false)</expression>
 			<output>true</output>
 		</test>
 		<test name="NotNull">
-			<expression>not null</expression>
+			<expression>(not null)</expression>
 			<output>null</output>
 		</test>
 	</group>
 	<group name="Or">
 		<test name="TrueOrTrue">
-			<expression>true or true</expression>
+			<expression>(true or true)</expression>
 			<output>true</output>
 		</test>
 		<test name="TrueOrFalse">
-			<expression>true or false</expression>
+			<expression>(true or false)</expression>
 			<output>true</output>
 		</test>
 		<test name="TrueOrNull">
-			<expression>true or null</expression>
+			<expression>(true or null)</expression>
 			<output>true</output>
 		</test>
 		<test name="FalseOrTrue">
-			<expression>false or true</expression>
+			<expression>(false or true)</expression>
 			<output>true</output>
 		</test>
 		<test name="FalseOrFalse">
-			<expression>false or false</expression>
+			<expression>(false or false)</expression>
 			<output>false</output>
 		</test>
 		<test name="FalseOrNull">
-			<expression>false or null</expression>
+			<expression>(false or null)</expression>
 			<output>null</output>
 		</test>
 		<test name="NullOrTrue">
-			<expression>null or true</expression>
+			<expression>(null or true)</expression>
 			<output>true</output>
 		</test>
 		<test name="NullOrFalse">
-			<expression>null or false</expression>
+			<expression>(null or false)</expression>
 			<output>null</output>
 		</test>
 		<test name="NullOrNull">
-			<expression>null or null</expression>
+			<expression>(null or null)</expression>
 			<output>null</output>
 		</test>
 	</group>
 	<group name="Xor">
 		<test name="TrueXorTrue">
-			<expression>true xor true</expression>
+			<expression>(true xor true)</expression>
 			<output>false</output>
 		</test>
 		<test name="TrueXorFalse">
-			<expression>true xor false</expression>
+			<expression>(true xor false)</expression>
 			<output>true</output>
 		</test>
 		<test name="TrueXorNull">
-			<expression>true xor null</expression>
+			<expression>(true xor null)</expression>
 			<output>null</output>
 		</test>
 		<test name="FalseXorTrue">
-			<expression>false xor true</expression>
+			<expression>(false xor true)</expression>
 			<output>true</output>
 		</test>
 		<test name="FalseXorFalse">
-			<expression>false xor false</expression>
+			<expression>(false xor false)</expression>
 			<output>false</output>
 		</test>
 		<test name="FalseXorNull">
-			<expression>false xor null</expression>
+			<expression>(false xor null)</expression>
 			<output>null</output>
 		</test>
 		<test name="NullXorTrue">
-			<expression>null xor true</expression>
+			<expression>(null xor true)</expression>
 			<output>null</output>
 		</test>
 		<test name="NullXorFalse">
-			<expression>null xor false</expression>
+			<expression>(null xor false)</expression>
 			<output>null</output>
 		</test>
 		<test name="NullXorNull">
-			<expression>null xor null</expression>
+			<expression>(null xor null)</expression>
 			<output>null</output>
 		</test>
 	</group>

--- a/engine.fhir/src/test/resources/org/hl7/fhirpath/cql/CqlStringOperatorsTest.xml
+++ b/engine.fhir/src/test/resources/org/hl7/fhirpath/cql/CqlStringOperatorsTest.xml
@@ -8,7 +8,7 @@
 		</test>
 		<test name="CombineEmptyList">
 			<expression>Combine({})</expression>
-			<output>null</output>
+			<output>''</output>
 		</test>
 		<test name="CombineABC">
 			<expression>Combine({'a', 'b', 'c'})</expression>
@@ -224,7 +224,7 @@
 			<output>'Who put the bang in the bang she bang she bang?'</output>
 		</test>
 		<test name="ReplaceMatchesSpaces">
-			<expression>ReplaceMatches('All that glitters is not gold', '\\s', '$$')</expression>
+			<expression>ReplaceMatches('All that glitters is not gold', '\\s', '\\$')</expression>
 			<output>'All$that$glitters$is$not$gold'</output>
 		</test>
 	</group>


### PR DESCRIPTION
CQF-1277
n CqlLogicalOperatorsTest.xml :

Enclosed all test expressions in parentheses to force cql precedence rules to evaluate the expression prior to evaluating the '=' operation.

 Consider the test that fails: FalseAndTrue,  with the expression:  'false and true' with the expected outcome 'false'.

The actual CQL statement that is evaluated by the test harness during processing the test is:   false and true = false.  (i.e.  <test exprression> = <test outcome>)

Given the CQL operator precedence, the '=' takes precedence over the 'and', so the evaluation effectively proceeds as:   false and (true = false), which becomes 'false and false' which finally results in false - thus failing the test.

If we instead enclose the expression in parens, then the test harness' CQL will be (false and true) = false,   which becomes false = false, which evaluates to 'true', thus passing the test.

Now consider one of the tests that doesn't fail. - TrueAndFalse, with the epxression 'true and false' and the outcome 'false'.

The evaluated CQL during the processing of the test is  'true and false = false'.  Again, given the precedence primacy of '=' over 'and', the effective expression is 'true and (false = false)'  which becomes 'true and true', which finally becomse 'true', thus passing the test.  

However, this test is really testing the primacy of '=' over 'and', which isn't the intent of the test.  Instead, as with the previous example, we need to wrap the expression in parens so that the expression is evaluated as intended, prior to the '='. 

Therefore, all test expressions in these logical tests should be wrapped in parens.
-------------------------------------------------------------------------------------------------------------------------------
 CQF-1278 
In cqlstringtests.xml:

CombineEmptyList
     Combine({})  has expected output of null.   Expected output should be an empty string, ''
     
     
ReplaceMatchesSpaces
   The last argument in the ReplaceMatches expression,  '$$', is incorrect.  It Should be <backslash><backslash>$
   
   
DateTimeToString3 
   ToString(<datetime>)  should return '2000-01-01T08:25:25.300-07:00', but current implementation leaves off the timezone offset. This is a bug in the engine.