### PR TITLE
CQF-1270 Enhanced exprression for test RollOutInterval.

### DIFF
--- a/engine.fhir/src/test/resources/org/hl7/fhirpath/cql/CqlAggregateTest.xml
+++ b/engine.fhir/src/test/resources/org/hl7/fhirpath/cql/CqlAggregateTest.xml
@@ -7,14 +7,16 @@
 			<output>120</output>
 		</test>
     <test name="RolledOutIntervals">
-      <expression>MedicationRequestIntervals M
-    aggregate R starting (null as List&lt;Interval&lt;DateTime>>): R union ({
-      M X
-        let S: Max({ end of Last(R) + 1 day, start of X }),
+      <expression>({Interval[DateTime(2022, 1, 8, 13, 0, 0, 0), DateTime(2022, 1, 15, 16, 0, 0, 0)],
+                    Interval[DateTime(2022, 1,10, 15, 0, 0, 0), DateTime(2022, 1, 20, 20, 0, 0, 0)],
+                    Interval[DateTime(2022, 1,25, 10, 0, 0, 0), DateTime(2022, 1, 30, 15, 0, 0, 0)]}) M
+          aggregate R starting (null as List<Interval <DateTime> >):
+          R union ({M X
+          let S: Max({ end of Last(R) + 1 day, start of X }),
           E: S + duration in days of X
-        return Interval[S, E]
-    })</expression>
-      <output>TODO</output>
+          return Interval[S, E]
+          })</expression>
+      <output>TODO pending fix to CQL aggregate function</output>
       <!-- Translation Error: Could not resolve identifier MedicationRequestIntervals in the current library. -->
     </test>
   </group>


### PR DESCRIPTION
Re:  Ref: CqlAggregateTest.xml

The CQL aggregate function appears to be in error.  (See issue https://github.com/DBCG/cql_engine/issues/553). Until that issue is resolved, the (2) tests in the aggregate test xml cannot be evaluated.

However, the 2nd test,  "RolledOutIntervals", was both syntactically in error and referenced non-existing intervals.  This PR addresses that.  Added an arbitrary list of intervals as the inline data source for the expression, and also corrected the syntax of the expression.