### PR TITLE
CQF-1270 Updated test expression in testCQLAggregate. 

### DIFF
--- a/engine.fhir/src/test/resources/org/hl7/fhirpath/cql/CqlAggregateTest.xml
+++ b/engine.fhir/src/test/resources/org/hl7/fhirpath/cql/CqlAggregateTest.xml
@@ -1,21 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://hl7.org/fhirpath/tests" xsi:schemaLocation="http://hl7.org/fhirpath/tests ../../testSchema/testSchema.xsd"
-  name="CqlAggregateTest" reference="http://build.fhir.org/ig/HL7/cql/03-developersguide.html#aggregate-queries">
-	<group name="AggregateTests">
-		<test name="FactorialOfFive">
-			<expression>({ 1, 2, 3, 4, 5 }) Num aggregate Result starting 1: Result * Num</expression>
-			<output>120</output>
-		</test>
-    <test name="RolledOutIntervals">
-      <expression>MedicationRequestIntervals M
-    aggregate R starting (null as List&lt;Interval&lt;DateTime>>): R union ({
-      M X
-        let S: Max({ end of Last(R) + 1 day, start of X }),
-          E: S + duration in days of X
-        return Interval[S, E]
-    })</expression>
-      <output>TODO</output>
-      <!-- Translation Error: Could not resolve identifier MedicationRequestIntervals in the current library. -->
-    </test>
-  </group>
+       name="CqlAggregateTest" reference="http://build.fhir.org/ig/HL7/cql/03-developersguide.html#aggregate-queries">
+    <group name="AggregateTests">
+        <test name="FactorialOfFive">
+            <expression>({ 1, 2, 3, 4, 5 }) Num aggregate Result starting 1: Result * Num</expression>
+            <output>120</output>
+        </test>
+        <test name="RolledOutIntervals">
+            <expression>({Interval[DateTime(2022, 1, 8, 13, 0, 0, 0), DateTime(2022, 1, 15, 16, 0, 0, 0)],
+                          Interval[DateTime(2022, 1,10, 15, 0, 0, 0), DateTime(2022, 1, 20, 20, 0, 0, 0)],
+                          Interval[DateTime(2022, 1,25, 10, 0, 0, 0), DateTime(2022, 1, 30, 15, 0, 0, 0)]}) M
+                aggregate R starting (null as List&lt;Interval &lt;DateTime> >):
+                   R union ({M X
+                             let S: Max({ end of Last(R) + 1 day, start of X }),
+                   E: S + duration in days of X
+                   return Interval[S, E]
+                })</expression>
+            <output>TODO pending implementation of CQL aggregate function</output>
+        </test>
+    </group>
 </tests>


### PR DESCRIPTION
Note: cql aggregate fn not implemented yet.  This pr only updates an aggregate test expression to get rid of external query and replace with in-line declaration of data as the source.

