### PR TITLE
Activate service loaders

### DIFF
--- a/engine.fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/model/TestDstu2ModelResolver.java
+++ b/engine.fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/model/TestDstu2ModelResolver.java
@@ -13,7 +13,7 @@ import ca.uhn.fhir.context.FhirVersionEnum;
 
 import org.cqframework.cql.cql2elm.ModelManager;
 import org.cqframework.cql.cql2elm.model.Model;
-import org.hl7.elm.r1.VersionedIdentifier;
+import org.hl7.cql.model.ModelIdentifier;
 import org.hl7.elm_modelinfo.r1.ClassInfo;
 import org.hl7.elm_modelinfo.r1.TypeInfo;
 
@@ -71,7 +71,7 @@ public class TestDstu2ModelResolver {
     public void resolveModelInfoTests() {
         ModelResolver resolver = new Dstu2FhirModelResolver();
         ModelManager mm = new ModelManager();
-        Model m = mm.resolveModel(new VersionedIdentifier().withId("FHIR").withVersion("1.0.2"));
+        Model m = mm.resolveModel(new ModelIdentifier().withId("FHIR").withVersion("1.0.2"));
 
         List<TypeInfo> typeInfos = m.getModelInfo().getTypeInfo();
 

--- a/engine.fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/model/TestDstu3ModelResolver.java
+++ b/engine.fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/model/TestDstu3ModelResolver.java
@@ -11,7 +11,7 @@ import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;
 import org.cqframework.cql.cql2elm.ModelManager;
 import org.cqframework.cql.cql2elm.model.Model;
-import org.hl7.elm.r1.VersionedIdentifier;
+import org.hl7.cql.model.ModelIdentifier;
 import org.hl7.elm_modelinfo.r1.ClassInfo;
 import org.hl7.elm_modelinfo.r1.TypeInfo;
 import org.hl7.fhir.dstu3.model.Enumeration;
@@ -109,7 +109,7 @@ public class TestDstu3ModelResolver {
     public void resolveModelInfoTests() {
         ModelResolver resolver = new Dstu3FhirModelResolver(FhirContext.forCached(FhirVersionEnum.DSTU3));
         ModelManager mm = new ModelManager();
-        Model m = mm.resolveModel(new VersionedIdentifier().withId("FHIR").withVersion("3.0.0"));
+        Model m = mm.resolveModel(new ModelIdentifier().withId("FHIR").withVersion("3.0.0"));
 
         List<TypeInfo> typeInfos = m.getModelInfo().getTypeInfo();
 

--- a/engine.fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/model/TestR4ModelResolver.java
+++ b/engine.fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/model/TestR4ModelResolver.java
@@ -15,7 +15,7 @@ import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;
 import org.cqframework.cql.cql2elm.ModelManager;
 import org.cqframework.cql.cql2elm.model.Model;
-import org.hl7.elm.r1.VersionedIdentifier;
+import org.hl7.cql.model.ModelIdentifier;
 import org.hl7.elm_modelinfo.r1.ClassInfo;
 import org.hl7.elm_modelinfo.r1.TypeInfo;
 import org.hl7.fhir.r4.model.DateTimeType;
@@ -166,7 +166,7 @@ public class TestR4ModelResolver {
     public void modelInfo400Tests() {
         ModelResolver resolver = new R4FhirModelResolver(FhirContext.forCached(FhirVersionEnum.R4));
         ModelManager mm = new ModelManager();
-        Model m = mm.resolveModel(new VersionedIdentifier().withId("FHIR").withVersion("4.0.1"));
+        Model m = mm.resolveModel(new ModelIdentifier().withId("FHIR").withVersion("4.0.1"));
 
         List<TypeInfo> typeInfos = m.getModelInfo().getTypeInfo();
 
@@ -200,7 +200,7 @@ public class TestR4ModelResolver {
     public void modelInfo401Tests() throws Exception {
         ModelResolver resolver = new R4FhirModelResolver(FhirContext.forCached(FhirVersionEnum.R4));
         ModelManager mm = new ModelManager();
-        Model m = mm.resolveModel(new VersionedIdentifier().withId("FHIR").withVersion("4.0.1"));
+        Model m = mm.resolveModel(new ModelIdentifier().withId("FHIR").withVersion("4.0.1"));
 
         List<TypeInfo> typeInfos = m.getModelInfo().getTypeInfo();
 

--- a/engine.jackson/src/main/resources/META-INF/services/org.opencds.cqf.cql.engine.serializing.CqlLibraryReaderProvider
+++ b/engine.jackson/src/main/resources/META-INF/services/org.opencds.cqf.cql.engine.serializing.CqlLibraryReaderProvider
@@ -1,0 +1,1 @@
+org.opencds.cqf.cql.engine.serializing.jackson.CqlLibraryReaderProvider

--- a/engine.jackson/src/test/java/org/opencds/cqf/cql/engine/serializing/ServiceLoaderTest.java
+++ b/engine.jackson/src/test/java/org/opencds/cqf/cql/engine/serializing/ServiceLoaderTest.java
@@ -1,0 +1,14 @@
+package org.opencds.cqf.cql.engine.serializing;
+
+import static org.testng.AssertJUnit.assertNotNull;
+
+import org.cqframework.cql.cql2elm.LibraryContentType;
+import org.testng.annotations.Test;
+
+public class ServiceLoaderTest {
+    @Test
+    void loaderIsAvailable() {
+        assertNotNull(CqlLibraryReaderFactory.getReader(LibraryContentType.JSON.mimeType()));
+        assertNotNull(CqlLibraryReaderFactory.getReader(LibraryContentType.XML.mimeType()));
+    }
+}

--- a/engine.jaxb/pom.xml
+++ b/engine.jaxb/pom.xml
@@ -43,6 +43,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>javax.json</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>info.cqframework</groupId>
             <artifactId>cql-to-elm</artifactId>
             <scope>test</scope>

--- a/engine.jaxb/src/main/resources/META-INF/services/org.opencds.cqf.cql.engine.serializing.CqlLibraryReaderProvider
+++ b/engine.jaxb/src/main/resources/META-INF/services/org.opencds.cqf.cql.engine.serializing.CqlLibraryReaderProvider
@@ -1,0 +1,1 @@
+org.opencds.cqf.cql.engine.serializing.jaxb.CqlLibraryReaderProvider

--- a/engine.jaxb/src/test/java/org/opencds/cqf/cql/engine/serializing/ServiceLoaderTest.java
+++ b/engine.jaxb/src/test/java/org/opencds/cqf/cql/engine/serializing/ServiceLoaderTest.java
@@ -1,0 +1,14 @@
+package org.opencds.cqf.cql.engine.serializing;
+
+import static org.testng.AssertJUnit.assertNotNull;
+
+import org.cqframework.cql.cql2elm.LibraryContentType;
+import org.testng.annotations.Test;
+
+public class ServiceLoaderTest {
+    @Test
+    void loaderIsAvailable() {
+        assertNotNull(CqlLibraryReaderFactory.getReader(LibraryContentType.JSON.mimeType()));
+        assertNotNull(CqlLibraryReaderFactory.getReader(LibraryContentType.XML.mimeType()));
+    }
+}

--- a/engine/src/main/java/org/opencds/cqf/cql/engine/serializing/CqlLibraryReaderFactory.java
+++ b/engine/src/main/java/org/opencds/cqf/cql/engine/serializing/CqlLibraryReaderFactory.java
@@ -19,6 +19,6 @@ public class CqlLibraryReaderFactory {
         if (providers(false).hasNext()) {
             return providers(false).next().create(contentType);
         }
-        throw new RuntimeException("No ElmLibraryReaderProviders found");
+        throw new RuntimeException("No ElmLibraryReaderProviders found for " + contentType);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,13 @@
                 <scope>test</scope>
             </dependency>
 
+            <dependency>
+                <groupId>org.glassfish</groupId>
+                <artifactId>javax.json</artifactId>
+                <version>1.0.4</version>
+                <scope>test</scope>
+            </dependency>
+
             <!-- Jackson dependencies -->
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <jackson.version>2.13.2</jackson.version>
         <jackson-databind.version>2.13.2.1</jackson-databind.version>
-        <cqframework.version>2.0.0</cqframework.version>
+        <cqframework.version>2.1.0-SNAPSHOT</cqframework.version>
         <hapi.version>6.0.1</hapi.version>
         <slf4j.version>1.7.29</slf4j.version>
         <surefire.version>3.0.0-M7</surefire.version>


### PR DESCRIPTION
1. Adds the property files to activate service loaders
2. Moves engine to Translator 2.1.0
3. Renames VersionIdentifer to ModelIndentifer (Translator 2.1-Snapshot)
4. Adds javax.json when using eclipse.moxy (Translator 2.1-Snapshot)