### PR TITLE
Forcing Woodstox on all Jackson XML modules. 

### DIFF
--- a/engine.jackson/src/main/java/org/opencds/cqf/cql/engine/serializing/jackson/XmlCqlMapper.java
+++ b/engine.jackson/src/main/java/org/opencds/cqf/cql/engine/serializing/jackson/XmlCqlMapper.java
@@ -1,9 +1,12 @@
 package org.opencds.cqf.cql.engine.serializing.jackson;
 
+import com.ctc.wstx.stax.WstxInputFactory;
+import com.ctc.wstx.stax.WstxOutputFactory;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.dataformat.xml.XmlFactory;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator;
 import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
@@ -17,7 +20,11 @@ import org.opencds.cqf.cql.engine.elm.execution.Executable;
 import org.opencds.cqf.cql.engine.serializing.jackson.mixins.*;
 
 public class XmlCqlMapper {
-    private static final XmlMapper mapper = XmlMapper.builder()
+    private static final XmlMapper mapper = XmlMapper
+            // TODO: Remove new XmlFactory(new WstxInputFactory(), new WstxOutputFactory()) in the future when Android
+            //  receives an implementation of javax.xml.stream.XMLInputFactory.newFactory ('xml-apis:xml-apis:1.4.01')
+            // Fixes ClinicalQualityLanguage#768: Forces the use of Woodstock for Android users.
+            .builder(new XmlFactory(new WstxInputFactory(), new WstxOutputFactory()))
             .defaultUseWrapper(true)
             .defaultMergeable(true)
             .enable(ToXmlGenerator.Feature.WRITE_XML_DECLARATION)


### PR DESCRIPTION
Same fix as https://github.com/cqframework/clinical_quality_language/issues/768

A Java11-on-Android issue happens on all `XmlMapper.builder()` calls. The default [XmlFactory](https://github.com/FasterXML/jackson-dataformat-xml/blob/9bdd0af7b6ec606e0dc8a6c19013b5952ae5b5d2/src/main/java/com/fasterxml/jackson/dataformat/xml/XmlFactory.java#L115) provided by Jackson calls a JDK11's Streaming API for XML (StAX) [javax.xml.stream.XMLInputFactory.newFactory](https://docs.oracle.com/en/java/javase/11/docs/api/java.xml/javax/xml/stream/XMLInputFactory.html#newFactory(java.lang.String,java.lang.ClassLoader)) function that does not exist on Android. That function is a simple service loader to find the `XMLInputFactory` and `XMLOutputFactory` implementations, which are provided [Woodstox](https://github.com/FasterXML/woodstox), a current forced dependency in our Jackson modules. 

This issue can be easily solved by bypassing the service loader and hardcoding the use of Woodstox's Input and Output Factories: 
```java
XmlMapper.builder(new XmlFactory(new WstxInputFactory(), new WstxOutputFactory()))...
```
Instead of 
```java
XmlMapper.builder()...
```