### PR TITLE
Fix race condition in LibraryReaderFactory

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -38,6 +38,7 @@
         "SNOMED",
         "sublist",
         "sublists",
+        "testng",
         "ucum",
         "unpair"
     ],

--- a/engine.fhir/pom.xml
+++ b/engine.fhir/pom.xml
@@ -61,17 +61,6 @@
             <groupId>ca.uhn.hapi.fhir</groupId>
             <artifactId>hapi-fhir-structures-r5</artifactId>
         </dependency>
-
-        <dependency>
-            <groupId>xpp3</groupId>
-            <artifactId>xpp3</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>xpp3</groupId>
-            <artifactId>xpp3_xpath</artifactId>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
             <artifactId>wiremock-jre8</artifactId>

--- a/engine.fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/model/FhirModelResolver.java
+++ b/engine.fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/model/FhirModelResolver.java
@@ -10,7 +10,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import ca.uhn.fhir.context.*;
 import org.hl7.fhir.exceptions.FHIRException;
 import org.hl7.fhir.instance.model.api.IAnyResource;
 import org.hl7.fhir.instance.model.api.IBase;
@@ -30,6 +29,15 @@ import org.opencds.cqf.cql.engine.runtime.Precision;
 import org.opencds.cqf.cql.engine.runtime.TemporalHelper;
 import org.opencds.cqf.cql.engine.runtime.Time;
 
+import ca.uhn.fhir.context.BaseRuntimeChildDefinition;
+import ca.uhn.fhir.context.BaseRuntimeElementCompositeDefinition;
+import ca.uhn.fhir.context.BaseRuntimeElementDefinition;
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.context.RuntimeChildChoiceDefinition;
+import ca.uhn.fhir.context.RuntimeChildPrimitiveDatatypeDefinition;
+import ca.uhn.fhir.context.RuntimeChildResourceBlockDefinition;
+import ca.uhn.fhir.context.RuntimeChildResourceDefinition;
+import ca.uhn.fhir.context.RuntimeResourceDefinition;
 import ca.uhn.fhir.model.api.TemporalPrecisionEnum;
 
 // TODO: Probably quite a bit of redundancy here. Probably only really need the BaseType and the PrimitiveType

--- a/engine.jackson/pom.xml
+++ b/engine.jackson/pom.xml
@@ -50,18 +50,6 @@
             <version>${jackson.version}</version>
         </dependency>
 
-        <!-- This depedency adds to the javax.xml.namespace package which is not valid in Java 9+-->
-        <dependency>
-            <groupId>xpp3</groupId>
-            <artifactId>xpp3</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>xpp3</groupId>
-            <artifactId>xpp3_xpath</artifactId>
-            <scope>test</scope>
-        </dependency>
-
         <dependency>
             <groupId>info.cqframework</groupId>
             <artifactId>cql-to-elm</artifactId>

--- a/engine.jackson/src/test/java/org/opencds/cqf/cql/engine/serializing/ServiceLoaderTest.java
+++ b/engine.jackson/src/test/java/org/opencds/cqf/cql/engine/serializing/ServiceLoaderTest.java
@@ -1,12 +1,10 @@
 package org.opencds.cqf.cql.engine.serializing;
 
-import static java.util.concurrent.CompletableFuture.allOf;
 import static java.util.concurrent.CompletableFuture.runAsync;
 import static java.util.stream.IntStream.range;
 import static org.testng.AssertJUnit.assertNotNull;
 
 import java.io.IOException;
-import java.util.concurrent.CompletableFuture;
 
 import org.cqframework.cql.cql2elm.LibraryContentType;
 import org.testng.annotations.Test;
@@ -21,10 +19,9 @@ public class ServiceLoaderTest {
 
     @Test
     void multiThreadedServiceLoader() {
-        var futures = range(0,10)
-            .mapToObj(x -> runAsync(this::loadReader));
-
-        allOf(futures.toArray(CompletableFuture[]::new)).join();
+        range(0,100)
+            .mapToObj(x -> runAsync(this::loadReader))
+            .forEach(x -> x.join());;
     }
 
     void loadReader() {

--- a/engine.jackson/src/test/java/org/opencds/cqf/cql/engine/serializing/ServiceLoaderTest.java
+++ b/engine.jackson/src/test/java/org/opencds/cqf/cql/engine/serializing/ServiceLoaderTest.java
@@ -2,6 +2,10 @@ package org.opencds.cqf.cql.engine.serializing;
 
 import static org.testng.AssertJUnit.assertNotNull;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.concurrent.CompletableFuture;
+
 import org.cqframework.cql.cql2elm.LibraryContentType;
 import org.testng.annotations.Test;
 
@@ -10,5 +14,25 @@ public class ServiceLoaderTest {
     void loaderIsAvailable() {
         assertNotNull(CqlLibraryReaderFactory.getReader(LibraryContentType.JSON.mimeType()));
         assertNotNull(CqlLibraryReaderFactory.getReader(LibraryContentType.XML.mimeType()));
+    }
+
+    @Test
+    void multiThreadedServiceLoader() {
+        var futures = new ArrayList<CompletableFuture<Void>>();
+        for (int i = 0; i < 10; i++) {
+            futures.add(CompletableFuture.runAsync(this::loadReader));
+        }
+
+        CompletableFuture.allOf(futures.toArray(new CompletableFuture[futures.size()])).join();
+    }
+
+    void loadReader() {
+        var reader = CqlLibraryReaderFactory.getReader(LibraryContentType.JSON.mimeType());
+        try {
+            reader.read(JsonCqlLibraryReaderTest.class.getResourceAsStream("EXM108.json"));
+        }
+        catch(IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/engine.jackson/src/test/java/org/opencds/cqf/cql/engine/serializing/ServiceLoaderTest.java
+++ b/engine.jackson/src/test/java/org/opencds/cqf/cql/engine/serializing/ServiceLoaderTest.java
@@ -1,13 +1,16 @@
 package org.opencds.cqf.cql.engine.serializing;
 
+import static java.util.concurrent.CompletableFuture.allOf;
+import static java.util.concurrent.CompletableFuture.runAsync;
+import static java.util.stream.IntStream.range;
 import static org.testng.AssertJUnit.assertNotNull;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.concurrent.CompletableFuture;
 
 import org.cqframework.cql.cql2elm.LibraryContentType;
 import org.testng.annotations.Test;
+
 
 public class ServiceLoaderTest {
     @Test
@@ -18,12 +21,10 @@ public class ServiceLoaderTest {
 
     @Test
     void multiThreadedServiceLoader() {
-        var futures = new ArrayList<CompletableFuture<Void>>();
-        for (int i = 0; i < 10; i++) {
-            futures.add(CompletableFuture.runAsync(this::loadReader));
-        }
+        var futures = range(0,10)
+            .mapToObj(x -> runAsync(this::loadReader));
 
-        CompletableFuture.allOf(futures.toArray(new CompletableFuture[futures.size()])).join();
+        allOf(futures.toArray(CompletableFuture[]::new)).join();
     }
 
     void loadReader() {

--- a/engine.jaxb/pom.xml
+++ b/engine.jaxb/pom.xml
@@ -24,18 +24,6 @@
             <version>2.1.0-SNAPSHOT</version>
         </dependency>
 
-        <!-- This depedency adds to the javax.xml.namespace package which is not valid in Java 9+-->
-        <dependency>
-            <groupId>xpp3</groupId>
-            <artifactId>xpp3</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>xpp3</groupId>
-            <artifactId>xpp3_xpath</artifactId>
-            <scope>test</scope>
-        </dependency>
-
         <!-- Jaxb implementation of choice -->
         <dependency>
             <groupId>org.eclipse.persistence</groupId>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -47,18 +47,6 @@
             <artifactId>ucum</artifactId>
         </dependency>
 
-        <!-- This depedency adds to the javax.xml.namespace package which is not valid in Java 9+-->
-        <dependency>
-            <groupId>xpp3</groupId>
-            <artifactId>xpp3</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>xpp3</groupId>
-            <artifactId>xpp3_xpath</artifactId>
-            <scope>test</scope>
-        </dependency>
-
         <dependency>
             <groupId>info.cqframework</groupId>
             <artifactId>cql-to-elm</artifactId>

--- a/engine/src/main/java/org/opencds/cqf/cql/engine/serializing/CqlLibraryReaderFactory.java
+++ b/engine/src/main/java/org/opencds/cqf/cql/engine/serializing/CqlLibraryReaderFactory.java
@@ -5,10 +5,12 @@ import java.util.ServiceLoader;
 
 public class CqlLibraryReaderFactory {
 
-    static ServiceLoader<CqlLibraryReaderProvider> loader = ServiceLoader
-            .load(CqlLibraryReaderProvider.class);
+    private CqlLibraryReaderFactory() {
+    }
 
     public static synchronized Iterator<CqlLibraryReaderProvider> providers(boolean refresh) {
+        var loader = ServiceLoader
+                .load(CqlLibraryReaderProvider.class);
         if (refresh) {
             loader.reload();
         }
@@ -19,9 +21,19 @@ public class CqlLibraryReaderFactory {
     public static CqlLibraryReader getReader(String contentType) {
         var providers = providers(false);
         if (providers.hasNext()) {
-            return providers.next().create(contentType);
+            CqlLibraryReaderProvider p = providers.next();
+            if (providers.hasNext()) {
+                throw new RuntimeException(String.join(" ",
+                        "Multiple CqlLibraryReaderProviders found on the classpath.",
+                        "You need to remove a reference to either the 'engine.jackson' or the 'engine.jaxb' package"));
+            }
+
+            return p.create(contentType);
         }
 
-        throw new RuntimeException("No ElmLibraryReaderProviders found for " + contentType);
+        throw new RuntimeException(String.join(" ",
+                "No CqlLibraryReaderProviders found on the classpath.",
+                "You need to add a reference to one of the 'engine.jackson' or 'engine.jaxb' packages,",
+                "or provide your own implementation."));
     }
 }

--- a/engine/src/main/java/org/opencds/cqf/cql/engine/serializing/CqlLibraryReaderFactory.java
+++ b/engine/src/main/java/org/opencds/cqf/cql/engine/serializing/CqlLibraryReaderFactory.java
@@ -8,7 +8,7 @@ public class CqlLibraryReaderFactory {
     private CqlLibraryReaderFactory() {
     }
 
-    public static synchronized Iterator<CqlLibraryReaderProvider> providers(boolean refresh) {
+    public static Iterator<CqlLibraryReaderProvider> providers(boolean refresh) {
         var loader = ServiceLoader
                 .load(CqlLibraryReaderProvider.class);
         if (refresh) {

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <jackson.version>2.13.2</jackson.version>
         <jackson-databind.version>2.13.2.1</jackson-databind.version>
-        <cqframework.version>2.1.0</cqframework.version>
+        <cqframework.version>2.2.0-SNAPSHOT</cqframework.version>
         <hapi.version>6.0.1</hapi.version>
         <slf4j.version>1.7.29</slf4j.version>
         <surefire.version>3.0.0-M7</surefire.version>
@@ -154,10 +154,6 @@
                         <groupId>xpp3</groupId>
                         <artifactId>xpp3</artifactId>
                     </exclusion>
-                    <exclusion>
-                        <groupId>xpp3</groupId>
-                        <artifactId>xpp3_xpath</artifactId>
-                    </exclusion>
                 </exclusions>
             </dependency>
 
@@ -186,48 +182,12 @@
                 <groupId>ca.uhn.hapi.fhir</groupId>
                 <artifactId>hapi-fhir-structures-r4</artifactId>
                 <version>${hapi.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>xpp3</groupId>
-                        <artifactId>xpp3</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>xpp3</groupId>
-                        <artifactId>xpp3_xpath</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
             <dependency>
                 <groupId>ca.uhn.hapi.fhir</groupId>
                 <artifactId>hapi-fhir-structures-r5</artifactId>
                 <version>${hapi.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>xpp3</groupId>
-                        <artifactId>xpp3</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>xpp3</groupId>
-                        <artifactId>xpp3_xpath</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
-
-            <!-- These break the engine in certain environments due to the
-            fact that they include the javax.xml.namespace package, which creates
-            a split package. We may need to filter or exclude them at some point
-            in the future.-->
-            <dependency>
-                <groupId>xpp3</groupId>
-                <artifactId>xpp3</artifactId>
-                <version>1.1.4c</version>
-            </dependency>
-            <dependency>
-                <groupId>xpp3</groupId>
-                <artifactId>xpp3_xpath</artifactId>
-                <version>1.1.4c</version>
-            </dependency>
-
 
             <!-- Testing dependencies -->
 
@@ -279,7 +239,7 @@
             <dependency>
                 <groupId>org.testng</groupId>
                 <artifactId>testng</artifactId>
-                <version>7.6.0</version>
+                <version>7.6.1</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -445,6 +405,8 @@
                     <version>3.4.0</version>
                     <configuration>
                         <source>11</source>
+                        <doclint>-missing</doclint>
+                        <quiet>true</quiet>
                     </configuration>
                     <executions>
                         <execution>


### PR DESCRIPTION
The PR adds more detailed error messages in the event the engine is misconfigured. It also fixes a race condition in the ReaderFactory where a single ServiceLoader was shared across threads. Additionally, this PR removes the `xpp3` dependency that was part of upstream projects, in particular the translator, that's now an optional dependency. This solves some Java 9+ build/tooling issues.