### PR TITLE
Formalizes compliance with Android 8, SDK 26 (2017+) 

### DIFF
--- a/engine.fhir/pom.xml
+++ b/engine.fhir/pom.xml
@@ -176,6 +176,18 @@
                     </configuration>
                 </plugin>
                 <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>animal-sniffer-maven-plugin</artifactId>
+                    <version>1.22</version>
+                    <configuration>
+                        <signature>
+                            <groupId>net.sf.androidscents.signature</groupId>
+                            <artifactId>android-api-level-26</artifactId>
+                            <version>8.0.0_r2</version>
+                        </signature>
+                    </configuration>
+                </plugin>
+                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <configuration>

--- a/engine.fhir/pom.xml
+++ b/engine.fhir/pom.xml
@@ -113,6 +113,12 @@
     </dependencies>
 
     <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
         <pluginManagement>
             <plugins>
                 <plugin>
@@ -162,18 +168,6 @@
                         <readOnly>false</readOnly>
                         <markGenerated>false</markGenerated>
                         <disableXmlSecurity>true</disableXmlSecurity>
-                    </configuration>
-                </plugin>
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>animal-sniffer-maven-plugin</artifactId>
-                    <version>1.22</version>
-                    <configuration>
-                        <signature>
-                            <groupId>net.sf.androidscents.signature</groupId>
-                            <artifactId>android-api-level-26</artifactId>
-                            <version>8.0.0_r2</version>
-                        </signature>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/engine.jackson/pom.xml
+++ b/engine.jackson/pom.xml
@@ -77,6 +77,12 @@
         </dependency>
     </dependencies>
     <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
         <pluginManagement>
             <plugins>
                 <plugin>
@@ -113,14 +119,6 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>animal-sniffer-maven-plugin</artifactId>
-                    <version>1.22</version>
-                    <configuration>
-                        <signature>
-                            <groupId>net.sf.androidscents.signature</groupId>
-                            <artifactId>android-api-level-26</artifactId>
-                            <version>8.0.0_r2</version>
-                        </signature>
-                    </configuration>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/engine.jackson/pom.xml
+++ b/engine.jackson/pom.xml
@@ -77,6 +77,16 @@
             <artifactId>elm-jackson</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <!-- dependencies required for Android -->
+        <!-- required to add due to the special QName Processor -->
+        <dependency>
+            <groupId>xerces</groupId>
+            <artifactId>xercesImpl</artifactId>
+            <version>2.12.2</version>
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
     <build>
         <pluginManagement>
@@ -110,6 +120,18 @@
                                 </limits>
                             </rule>
                         </rules>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>animal-sniffer-maven-plugin</artifactId>
+                    <version>1.22</version>
+                    <configuration>
+                        <signature>
+                            <groupId>net.sf.androidscents.signature</groupId>
+                            <artifactId>android-api-level-26</artifactId>
+                            <version>8.0.0_r2</version>
+                        </signature>
                     </configuration>
                 </plugin>
             </plugins>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -65,6 +65,12 @@
     </dependencies>
 
     <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
         <pluginManagement>
             <plugins>
                 <plugin>
@@ -128,18 +134,6 @@
                         <readOnly>false</readOnly>
                         <markGenerated>false</markGenerated>
                         <disableXmlSecurity>true</disableXmlSecurity>
-                    </configuration>
-                </plugin>
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>animal-sniffer-maven-plugin</artifactId>
-                    <version>1.22</version>
-                    <configuration>
-                        <signature>
-                            <groupId>net.sf.androidscents.signature</groupId>
-                            <artifactId>android-api-level-26</artifactId>
-                            <version>8.0.0_r2</version>
-                        </signature>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -143,6 +143,18 @@
                     </configuration>
                 </plugin>
                 <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>animal-sniffer-maven-plugin</artifactId>
+                    <version>1.22</version>
+                    <configuration>
+                        <signature>
+                            <groupId>net.sf.androidscents.signature</groupId>
+                            <artifactId>android-api-level-26</artifactId>
+                            <version>8.0.0_r2</version>
+                        </signature>
+                    </configuration>
+                </plugin>
+                <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
                     <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -556,6 +556,27 @@
                     <artifactId>maven-jxr-plugin</artifactId>
                     <version>3.2.0</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>animal-sniffer-maven-plugin</artifactId>
+                    <version>1.22</version>
+                    <configuration>
+                        <signature>
+                            <groupId>net.sf.androidscents.signature</groupId>
+                            <artifactId>android-api-level-26</artifactId>
+                            <version>8.0.0_r2</version>
+                        </signature>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>check-android-26-compliance</id>
+                            <phase>test</phase>
+                            <goals>
+                                <goal>check</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>


### PR DESCRIPTION
This PR formalizes this project's compliance with Android
1. Adds an Animal Sniffer plugin to check compliance with any runtime API when running `mvn test`
2. Selects modules `engine`, `engine.fhir` and `engine.jackson` to be checked for Android compliance. 
3. Establishes initial compliance to Android 8 - SDK 26, the minimum Android version the Translator is currently fully compliant with. 

**Important**: The plugin only verifies the source code in this project, not dependencies. 

For testing, add: 

```java
if (Optional.of(UUID.randomUUID()).isEmpty())
   throw new RuntimeException("Test");
```

in the desired module and run `mvn animal-sniffer:check`. 

Since the method `Optional.isEmpty` is not available on Android, the output should look like this: 

![Screen Shot 2022-09-25 at 6 28 31 PM](https://user-images.githubusercontent.com/532031/192168411-db5075f6-a686-4db9-9464-fd92e0a6f1c5.png)



