### PR TITLE
Adding the missing ExpandValueSet MixIn

### DIFF
--- a/engine.jackson/src/main/java/org/opencds/cqf/cql/engine/serializing/jackson/mixins/ExpressionMixin.java
+++ b/engine.jackson/src/main/java/org/opencds/cqf/cql/engine/serializing/jackson/mixins/ExpressionMixin.java
@@ -1,5 +1,6 @@
 package org.opencds.cqf.cql.engine.serializing.jackson.mixins;
 
+import org.cqframework.cql.elm.execution.ExpandValueSet;
 import org.opencds.cqf.cql.engine.elm.execution.*;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
@@ -66,6 +67,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
     @Type(value = ExistsEvaluator.class, name = "Exists"),
     @Type(value = ExpEvaluator.class, name = "Exp"),
     @Type(value = ExpandEvaluator.class, name = "Expand"),
+    @Type(value = ExpandValueSetEvaluator.class, name = "ExpandValueSet"),
     @Type(value = ExpressionDefEvaluator.class, name = "ExpressionDef"),
     @Type(value = ExpressionRefEvaluator.class, name = "ExpressionRef"),
     // @Type(value = FunctionDef.class, name = "FunctionDef"),

--- a/engine.jackson/src/main/java/org/opencds/cqf/cql/engine/serializing/jackson/mixins/ExpressionMixin.java
+++ b/engine.jackson/src/main/java/org/opencds/cqf/cql/engine/serializing/jackson/mixins/ExpressionMixin.java
@@ -1,6 +1,5 @@
 package org.opencds.cqf.cql.engine.serializing.jackson.mixins;
 
-import org.cqframework.cql.elm.execution.ExpandValueSet;
 import org.opencds.cqf.cql.engine.elm.execution.*;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;

--- a/engine.jackson/src/test/java/org/opencds/cqf/cql/engine/execution/ExpandValueSetTest.java
+++ b/engine.jackson/src/test/java/org/opencds/cqf/cql/engine/execution/ExpandValueSetTest.java
@@ -1,0 +1,46 @@
+package org.opencds.cqf.cql.engine.execution;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.opencds.cqf.cql.engine.runtime.Code;
+import org.opencds.cqf.cql.engine.terminology.CodeSystemInfo;
+import org.opencds.cqf.cql.engine.terminology.TerminologyProvider;
+import org.opencds.cqf.cql.engine.terminology.ValueSetInfo;
+import org.testng.annotations.Test;
+
+public class ExpandValueSetTest extends CqlExecutionTestBase {
+
+    @Test
+    public void testExpandValueSetRef() {
+        Code expected = new Code().withCode("M").withSystem("http://test.com/system");
+
+        TerminologyProvider terminologyProvider = new TerminologyProvider() {
+            public boolean in(Code code, ValueSetInfo valueSet) {
+                return true;
+            }
+
+            public Iterable<Code> expand(ValueSetInfo valueSet) {
+                return Collections.singletonList(expected);
+            }
+
+            public Code lookup(Code code, CodeSystemInfo codeSystem) {
+                return null;
+            }
+
+        };
+        Context ctx = new Context(library);
+        ctx.registerLibraryLoader(new TestLibraryLoader(getLibraryManager()));
+        ctx.registerTerminologyProvider(terminologyProvider);
+
+        @SuppressWarnings("unchecked")
+        List<Code> actual = (List<Code>)ctx.resolveExpressionRef("ExpandValueSet").getExpression().evaluate(ctx);
+        assertNotNull(actual);
+        assertEquals(actual.size(), 1);
+
+        CqlConceptTest.assertEqual(expected, actual.get(0));
+    }
+}

--- a/engine.jackson/src/test/resources/org/opencds/cqf/cql/engine/execution/ExpandValueSetTest.cql
+++ b/engine.jackson/src/test/resources/org/opencds/cqf/cql/engine/execution/ExpandValueSetTest.cql
@@ -1,0 +1,8 @@
+library ExpandValueSetTest
+
+valueset "Acute Pharyngitis": 'urn:oid:2.16.840.1.113883.3.464.1003.102.12.1011'
+valueset "Acute Tonsillitis": 'urn:oid:2.16.840.1.113883.3.464.1003.102.12.1012'
+
+define "ExpandValueSet":
+    "Acute Pharyngitis" union "Acute Tonsillitis"
+


### PR DESCRIPTION
Expand ValueSet operators were not created after parsing the library with Jackson and was causing the error: 

```
org.opencds.cqf.cql.engine.exception.CqlException: org.apache.commons.lang3.NotImplementedException: evaluate not implemented for class ExpandValueSet
    at org.opencds.cqf.cql.engine.elm.execution.Executable.evaluate(Executable.java:33)
```

This PR adds the MixIn for ExpandValueSetEvaluator and a test case to fix the problem. 