### PR TITLE
Added queryBatchThreshold in FhirQuery generation

### DIFF
--- a/engine.fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/retrieve/FhirQueryGeneratorFactory.java
+++ b/engine.fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/retrieve/FhirQueryGeneratorFactory.java
@@ -45,13 +45,16 @@ public class FhirQueryGeneratorFactory {
      */
     public static BaseFhirQueryGenerator create(ModelResolver modelResolver, SearchParameterResolver searchParameterResolver,
                                          TerminologyProvider terminologyProvider, Boolean shouldExpandValueSets,
-                                         Integer maxCodesPerQuery, Integer pageSize) throws FhirVersionMisMatchException {
+                                         Integer maxCodesPerQuery, Integer pageSize, Integer queryBatchThreshold) throws FhirVersionMisMatchException {
         BaseFhirQueryGenerator baseFhirQueryGenerator = create(modelResolver, searchParameterResolver, terminologyProvider);
         if (shouldExpandValueSets != null) {
             baseFhirQueryGenerator.setExpandValueSets(shouldExpandValueSets);
         }
         if (maxCodesPerQuery != null) {
             baseFhirQueryGenerator.setMaxCodesPerQuery(maxCodesPerQuery);
+        }
+        if (queryBatchThreshold != null) {
+            baseFhirQueryGenerator.setQueryBatchThreshold(queryBatchThreshold);
         }
         if (pageSize != null) {
             baseFhirQueryGenerator.setPageSize(pageSize);

--- a/engine.fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/retrieve/R4FhirQueryGenerator.java
+++ b/engine.fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/retrieve/R4FhirQueryGenerator.java
@@ -28,7 +28,8 @@ import org.opencds.cqf.cql.engine.terminology.TerminologyProvider;
 
 
 public class R4FhirQueryGenerator extends BaseFhirQueryGenerator {
-    public R4FhirQueryGenerator(SearchParameterResolver searchParameterResolver, TerminologyProvider terminologyProvider, ModelResolver modelResolver) throws FhirVersionMisMatchException {
+    public R4FhirQueryGenerator(SearchParameterResolver searchParameterResolver, TerminologyProvider terminologyProvider,
+                                ModelResolver modelResolver) throws FhirVersionMisMatchException {
         super(searchParameterResolver, terminologyProvider, modelResolver, searchParameterResolver.getFhirContext());
     }
 

--- a/engine.fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/retrieve/SearchParamFhirRetrieveProvider.java
+++ b/engine.fhir/src/main/java/org/opencds/cqf/cql/engine/fhir/retrieve/SearchParamFhirRetrieveProvider.java
@@ -14,7 +14,6 @@ import org.opencds.cqf.cql.engine.runtime.Interval;
 import ca.uhn.fhir.context.FhirContext;
 
 public abstract class SearchParamFhirRetrieveProvider extends TerminologyAwareRetrieveProvider {
-    
     protected FhirContext fhirContext;
     protected SearchParameterResolver searchParameterResolver;
     protected Integer pageSize;

--- a/engine.fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/retrieve/TestDstu3FhirQueryGenerator.java
+++ b/engine.fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/retrieve/TestDstu3FhirQueryGenerator.java
@@ -77,7 +77,7 @@ public class TestDstu3FhirQueryGenerator extends Dstu3FhirTest {
         return valueSet;
     }
 
-    private DataRequirement getCodeFilteredViaValueSetDataRequirement(String resourceType, String path, ValueSet valueSet) {
+    private DataRequirement getCodeFilteredDataRequirement(String resourceType, String path, ValueSet valueSet) {
         DataRequirement dataRequirement = new DataRequirement();
         dataRequirement.setType(resourceType);
         DataRequirement.DataRequirementCodeFilterComponent categoryCodeFilter = new DataRequirement.DataRequirementCodeFilterComponent();
@@ -88,42 +88,6 @@ public class TestDstu3FhirQueryGenerator extends Dstu3FhirTest {
 
         return dataRequirement;
     }
-
-//    private DataRequirement getCodeFilteredViaCodeableConceptDataRequirement(String resourceType, String path, ValueSet valueSet) {
-//        DataRequirement dataRequirement = new DataRequirement();
-//        dataRequirement.setType(resourceType);
-//        DataRequirement.DataRequirementCodeFilterComponent categoryCodeFilter = new DataRequirement.DataRequirementCodeFilterComponent();
-//        categoryCodeFilter.setPath(path);
-//        org.hl7.fhir.dstu3.model.Reference valueSetReference = new org.hl7.fhir.dstu3.model.Reference(valueSet.getUrl());
-//        categoryCodeFilter.setValueSet(valueSetReference);
-//        dataRequirement.setCodeFilter(java.util.Arrays.asList(categoryCodeFilter));
-//
-//        return dataRequirement;
-//    }
-//
-//    private DataRequirement getCodeFilteredViaCodingDataRequirement(String resourceType, String path, ValueSet valueSet) {
-//        DataRequirement dataRequirement = new DataRequirement();
-//        dataRequirement.setType(resourceType);
-//        DataRequirement.DataRequirementCodeFilterComponent categoryCodeFilter = new DataRequirement.DataRequirementCodeFilterComponent();
-//        categoryCodeFilter.setPath(path);
-//        org.hl7.fhir.dstu3.model.Reference valueSetReference = new org.hl7.fhir.dstu3.model.Reference(valueSet.getUrl());
-//        categoryCodeFilter.setValueSet(valueSetReference);
-//        dataRequirement.setCodeFilter(java.util.Arrays.asList(categoryCodeFilter));
-//
-//        return dataRequirement;
-//    }
-//
-//    private DataRequirement getCodeFilteredViaCodeDataRequirement(String resourceType, String path, ValueSet valueSet) {
-//        DataRequirement dataRequirement = new DataRequirement();
-//        dataRequirement.setType(resourceType);
-//        DataRequirement.DataRequirementCodeFilterComponent categoryCodeFilter = new DataRequirement.DataRequirementCodeFilterComponent();
-//        categoryCodeFilter.setPath(path);
-//        org.hl7.fhir.dstu3.model.Reference valueSetReference = new org.hl7.fhir.dstu3.model.Reference(valueSet.getUrl());
-//        categoryCodeFilter.setValueSet(valueSetReference);
-//        dataRequirement.setCodeFilter(java.util.Arrays.asList(categoryCodeFilter));
-//
-//        return dataRequirement;
-//    }
 
     @Test
     void testGetFhirQueriesObservation() {
@@ -138,7 +102,7 @@ public class TestDstu3FhirQueryGenerator extends Dstu3FhirTest {
 
         mockFhirRead("/ValueSet?url=http%3A%2F%2Fmyterm.com%2Ffhir%2FValueSet%2FMyValueSet", valueSetBundle);
 
-        DataRequirement dataRequirement = getCodeFilteredViaValueSetDataRequirement("Observation", "category", valueSet);
+        DataRequirement dataRequirement = getCodeFilteredDataRequirement("Observation", "category", valueSet);
 
         this.contextValues.put("Patient", "{{context.patientId}}");
         java.util.List<String> actual = this.generator.generateFhirQueries(dataRequirement, this.evaluationDateTime, this.contextValues, this.parameters, null);
@@ -162,7 +126,7 @@ public class TestDstu3FhirQueryGenerator extends Dstu3FhirTest {
 
         mockFhirRead("/ValueSet?url=http%3A%2F%2Fmyterm.com%2Ffhir%2FValueSet%2FMyValueSet", valueSetBundle);
 
-        DataRequirement dataRequirement = getCodeFilteredViaValueSetDataRequirement("Observation", "category", valueSet);
+        DataRequirement dataRequirement = getCodeFilteredDataRequirement("Observation", "category", valueSet);
 
         this.generator.setMaxCodesPerQuery(4);
         this.contextValues.put("Patient", "{{context.patientId}}");
@@ -252,7 +216,7 @@ public class TestDstu3FhirQueryGenerator extends Dstu3FhirTest {
         mockFhirRead("/ValueSet?url=http%3A%2F%2Fmyterm.com%2Ffhir%2FValueSet%2FMyValueSet", valueSetBundle);
         mockFhirRead("/ValueSet/MyValueSet/$expand", valueSet);
 
-        DataRequirement dataRequirement = getCodeFilteredViaValueSetDataRequirement("Observation", "category", valueSet);
+        DataRequirement dataRequirement = getCodeFilteredDataRequirement("Observation", "category", valueSet);
 
         this.generator.setMaxCodesPerQuery(4);
         this.generator.setExpandValueSets(true);
@@ -268,35 +232,66 @@ public class TestDstu3FhirQueryGenerator extends Dstu3FhirTest {
         assertEquals(actual.get(1), expectedQuery2);
     }
 
-//    @Test
-//    void testCodesExceedMaxUriLength() {
-//        ValueSet valueSet = getTestValueSet("MyValueSet", 200);
-//
-//        org.hl7.fhir.dstu3.model.Bundle valueSetBundle = new org.hl7.fhir.dstu3.model.Bundle();
-//        valueSetBundle.setType(Bundle.BundleType.SEARCHSET);
-//
-//        Bundle.BundleEntryComponent entry = new Bundle.BundleEntryComponent();
-//        entry.setResource(valueSet);
-//        valueSetBundle.addEntry(entry);
-//
-//        mockFhirRead("/ValueSet?url=http%3A%2F%2Fmyterm.com%2Ffhir%2FValueSet%2FMyValueSet", valueSetBundle);
-//        mockFhirRead("/ValueSet/MyValueSet/$expand", valueSet);
-//
-//        DataRequirement dataRequirement = getCodeFilteredViaValueSetDataRequirement("Observation", "category", valueSet);
-//
-//        this.generator.setMaxCodesPerQuery(400);
-//        this.generator.setMaxUriLength(20);
-//        this.generator.setExpandValueSets(true);
-//        this.engineContext.enterContext("Patient");
-//        this.engineContext.setContextValue("Patient", "{{context.patientId}}");
-//        java.util.List<String> actual = this.generator.generateFhirQueries(dataRequirement, this.engineContext, null);
-//
-//        String expectedQuery1 = "Observation?category=http://myterm.com/fhir/CodeSystem/MyValueSet|code0,http://myterm.com/fhir/CodeSystem/MyValueSet|code1,http://myterm.com/fhir/CodeSystem/MyValueSet|code2,http://myterm.com/fhir/CodeSystem/MyValueSet|code3&patient=Patient/{{context.patientId}}";
-//        String expectedQuery2 = "Observation?category=http://myterm.com/fhir/CodeSystem/MyValueSet|code4,http://myterm.com/fhir/CodeSystem/MyValueSet|code5,http://myterm.com/fhir/CodeSystem/MyValueSet|code6,http://myterm.com/fhir/CodeSystem/MyValueSet|code7&patient=Patient/{{context.patientId}}";
-//
-//        assertNotNull(actual);
-//        assertEquals(actual.size(), 2);
-//        assertEquals(actual.get(0), expectedQuery1);
-//        assertEquals(actual.get(1), expectedQuery2);
-//    }
+    @Test
+    void testMaxQueryThresholdExceeded() {
+        ValueSet valueSet = getTestValueSet("MyValueSet", 21);
+
+        Bundle valueSetBundle = new Bundle();
+        valueSetBundle.setType(Bundle.BundleType.SEARCHSET);
+
+        Bundle.BundleEntryComponent entry = new Bundle.BundleEntryComponent();
+        entry.setResource(valueSet);
+        valueSetBundle.addEntry(entry);
+
+        mockFhirRead("/ValueSet?url=http%3A%2F%2Fmyterm.com%2Ffhir%2FValueSet%2FMyValueSet", valueSetBundle);
+        mockFhirRead("/ValueSet/MyValueSet/$expand", valueSet);
+
+        DataRequirement dataRequirement = getCodeFilteredDataRequirement("Observation", "category", valueSet);
+
+        this.generator.setMaxCodesPerQuery(4);
+        this.generator.setExpandValueSets(true);
+        this.generator.setQueryBatchThreshold(5);
+        this.contextValues.put("Patient", "{{context.patientId}}");
+        java.util.List<String> actual = this.generator.generateFhirQueries(dataRequirement, this.evaluationDateTime, this.contextValues, this.parameters, null);
+
+        assertNotNull(actual);
+        assertEquals(actual.size(), 1);
+    }
+
+    @Test
+    void testMaxQueryThreshold() {
+        ValueSet valueSet = getTestValueSet("MyValueSet", 21);
+
+        Bundle valueSetBundle = new Bundle();
+        valueSetBundle.setType(Bundle.BundleType.SEARCHSET);
+
+        Bundle.BundleEntryComponent entry = new Bundle.BundleEntryComponent();
+        entry.setResource(valueSet);
+        valueSetBundle.addEntry(entry);
+
+        mockFhirRead("/ValueSet?url=http%3A%2F%2Fmyterm.com%2Ffhir%2FValueSet%2FMyValueSet", valueSetBundle);
+        mockFhirRead("/ValueSet/MyValueSet/$expand", valueSet);
+
+        DataRequirement dataRequirement = getCodeFilteredDataRequirement("Observation", "category", valueSet);
+
+        this.generator.setMaxCodesPerQuery(5);
+        this.generator.setExpandValueSets(true);
+        this.generator.setQueryBatchThreshold(5);
+        this.contextValues.put("Patient", "{{context.patientId}}");
+        java.util.List<String> actual = this.generator.generateFhirQueries(dataRequirement, this.evaluationDateTime, this.contextValues, this.parameters, null);
+
+        String expectedQuery1 = "Observation?category=http://myterm.com/fhir/CodeSystem/MyValueSet|code0,http://myterm.com/fhir/CodeSystem/MyValueSet|code1,http://myterm.com/fhir/CodeSystem/MyValueSet|code2,http://myterm.com/fhir/CodeSystem/MyValueSet|code3,http://myterm.com/fhir/CodeSystem/MyValueSet|code4&patient=Patient/{{context.patientId}}";
+        String expectedQuery2 = "Observation?category=http://myterm.com/fhir/CodeSystem/MyValueSet|code5,http://myterm.com/fhir/CodeSystem/MyValueSet|code6,http://myterm.com/fhir/CodeSystem/MyValueSet|code7,http://myterm.com/fhir/CodeSystem/MyValueSet|code8,http://myterm.com/fhir/CodeSystem/MyValueSet|code9&patient=Patient/{{context.patientId}}";
+        String expectedQuery3 = "Observation?category=http://myterm.com/fhir/CodeSystem/MyValueSet|code10,http://myterm.com/fhir/CodeSystem/MyValueSet|code11,http://myterm.com/fhir/CodeSystem/MyValueSet|code12,http://myterm.com/fhir/CodeSystem/MyValueSet|code13,http://myterm.com/fhir/CodeSystem/MyValueSet|code14&patient=Patient/{{context.patientId}}";
+        String expectedQuery4 = "Observation?category=http://myterm.com/fhir/CodeSystem/MyValueSet|code15,http://myterm.com/fhir/CodeSystem/MyValueSet|code16,http://myterm.com/fhir/CodeSystem/MyValueSet|code17,http://myterm.com/fhir/CodeSystem/MyValueSet|code18,http://myterm.com/fhir/CodeSystem/MyValueSet|code19&patient=Patient/{{context.patientId}}";
+        String expectedQuery5 = "Observation?category=http://myterm.com/fhir/CodeSystem/MyValueSet|code20&patient=Patient/{{context.patientId}}";
+
+        assertNotNull(actual);
+        assertEquals(actual.size(), 5);
+        assertEquals(actual.get(0), expectedQuery1);
+        assertEquals(actual.get(1), expectedQuery2);
+        assertEquals(actual.get(2), expectedQuery3);
+        assertEquals(actual.get(3), expectedQuery4);
+        assertEquals(actual.get(4), expectedQuery5);
+    }
 }

--- a/engine.fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/retrieve/TestR4FhirQueryGenerator.java
+++ b/engine.fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/retrieve/TestR4FhirQueryGenerator.java
@@ -262,35 +262,120 @@ public class TestR4FhirQueryGenerator extends R4FhirTest {
         assertEquals(actual.get(1), expectedQuery2);
     }
 
-//    @Test
-//    void testCodesExceedMaxUriLength() {
-//        ValueSet valueSet = getTestValueSet("MyValueSet", 200);
-//
-//        org.hl7.fhir.r4.model.Bundle valueSetBundle = new org.hl7.fhir.r4.model.Bundle();
-//        valueSetBundle.setType(Bundle.BundleType.SEARCHSET);
-//
-//        Bundle.BundleEntryComponent entry = new Bundle.BundleEntryComponent();
-//        entry.setResource(valueSet);
-//        valueSetBundle.addEntry(entry);
-//
-//        mockFhirRead("/ValueSet?url=http%3A%2F%2Fmyterm.com%2Ffhir%2FValueSet%2FMyValueSet", valueSetBundle);
-//        mockFhirRead("/ValueSet/MyValueSet/$expand", valueSet);
-//
-//        DataRequirement dataRequirement = getCodeFilteredDataRequirement("Observation", "category", valueSet);
-//
-//        this.generator.setMaxCodesPerQuery(400);
-//        this.generator.setMaxUriLength(20);
-//        this.generator.setExpandValueSets(true);
-//        this.engineContext.enterContext("Patient");
-//        this.engineContext.setContextValue("Patient", "{{context.patientId}}");
-//        java.util.List<String> actual = this.generator.generateFhirQueries(dataRequirement, this.engineContext, null);
-//
-//        String expectedQuery1 = "Observation?category=http://myterm.com/fhir/CodeSystem/MyValueSet|code0,http://myterm.com/fhir/CodeSystem/MyValueSet|code1,http://myterm.com/fhir/CodeSystem/MyValueSet|code2,http://myterm.com/fhir/CodeSystem/MyValueSet|code3&subject=Patient/{{context.patientId}}";
-//        String expectedQuery2 = "Observation?category=http://myterm.com/fhir/CodeSystem/MyValueSet|code4,http://myterm.com/fhir/CodeSystem/MyValueSet|code5,http://myterm.com/fhir/CodeSystem/MyValueSet|code6,http://myterm.com/fhir/CodeSystem/MyValueSet|code7&subject=Patient/{{context.patientId}}";
-//
-//        assertNotNull(actual);
-//        assertEquals(actual.size(), 2);
-//        assertEquals(actual.get(0), expectedQuery1);
-//        assertEquals(actual.get(1), expectedQuery2);
-//    }
+    @Test
+    void testQueryBatchThresholdExceeded() {
+        ValueSet valueSet = getTestValueSet("MyValueSet", 21);
+
+        org.hl7.fhir.r4.model.Bundle valueSetBundle = new org.hl7.fhir.r4.model.Bundle();
+        valueSetBundle.setType(Bundle.BundleType.SEARCHSET);
+
+        Bundle.BundleEntryComponent entry = new Bundle.BundleEntryComponent();
+        entry.setResource(valueSet);
+        valueSetBundle.addEntry(entry);
+
+        mockFhirRead("/ValueSet?url=http%3A%2F%2Fmyterm.com%2Ffhir%2FValueSet%2FMyValueSet", valueSetBundle);
+        mockFhirRead("/ValueSet/MyValueSet/$expand", valueSet);
+
+        DataRequirement dataRequirement = getCodeFilteredDataRequirement("Observation", "category", valueSet);
+
+        this.generator.setMaxCodesPerQuery(4);
+        this.generator.setExpandValueSets(true);
+        this.generator.setQueryBatchThreshold(5);
+        this.contextValues.put("Patient", "{{context.patientId}}");
+        java.util.List<String> actual = this.generator.generateFhirQueries(dataRequirement, this.evaluationDateTime, this.contextValues, this.parameters, null);
+
+        assertNotNull(actual);
+        assertEquals(actual.size(), 1);
+    }
+
+    @Test
+    void testQueryBatchThreshold() {
+        ValueSet valueSet = getTestValueSet("MyValueSet", 21);
+
+        org.hl7.fhir.r4.model.Bundle valueSetBundle = new org.hl7.fhir.r4.model.Bundle();
+        valueSetBundle.setType(Bundle.BundleType.SEARCHSET);
+
+        Bundle.BundleEntryComponent entry = new Bundle.BundleEntryComponent();
+        entry.setResource(valueSet);
+        valueSetBundle.addEntry(entry);
+
+        mockFhirRead("/ValueSet?url=http%3A%2F%2Fmyterm.com%2Ffhir%2FValueSet%2FMyValueSet", valueSetBundle);
+        mockFhirRead("/ValueSet/MyValueSet/$expand", valueSet);
+
+        DataRequirement dataRequirement = getCodeFilteredDataRequirement("Observation", "category", valueSet);
+
+        this.generator.setMaxCodesPerQuery(5);
+        this.generator.setExpandValueSets(true);
+        this.generator.setQueryBatchThreshold(5);
+        this.contextValues.put("Patient", "{{context.patientId}}");
+        java.util.List<String> actual = this.generator.generateFhirQueries(dataRequirement, this.evaluationDateTime, this.contextValues, this.parameters, null);
+
+        String expectedQuery1 = "Observation?category=http://myterm.com/fhir/CodeSystem/MyValueSet|code0,http://myterm.com/fhir/CodeSystem/MyValueSet|code1,http://myterm.com/fhir/CodeSystem/MyValueSet|code2,http://myterm.com/fhir/CodeSystem/MyValueSet|code3,http://myterm.com/fhir/CodeSystem/MyValueSet|code4&subject=Patient/{{context.patientId}}";
+        String expectedQuery2 = "Observation?category=http://myterm.com/fhir/CodeSystem/MyValueSet|code5,http://myterm.com/fhir/CodeSystem/MyValueSet|code6,http://myterm.com/fhir/CodeSystem/MyValueSet|code7,http://myterm.com/fhir/CodeSystem/MyValueSet|code8,http://myterm.com/fhir/CodeSystem/MyValueSet|code9&subject=Patient/{{context.patientId}}";
+        String expectedQuery3 = "Observation?category=http://myterm.com/fhir/CodeSystem/MyValueSet|code10,http://myterm.com/fhir/CodeSystem/MyValueSet|code11,http://myterm.com/fhir/CodeSystem/MyValueSet|code12,http://myterm.com/fhir/CodeSystem/MyValueSet|code13,http://myterm.com/fhir/CodeSystem/MyValueSet|code14&subject=Patient/{{context.patientId}}";
+        String expectedQuery4 = "Observation?category=http://myterm.com/fhir/CodeSystem/MyValueSet|code15,http://myterm.com/fhir/CodeSystem/MyValueSet|code16,http://myterm.com/fhir/CodeSystem/MyValueSet|code17,http://myterm.com/fhir/CodeSystem/MyValueSet|code18,http://myterm.com/fhir/CodeSystem/MyValueSet|code19&subject=Patient/{{context.patientId}}";
+        String expectedQuery5 = "Observation?category=http://myterm.com/fhir/CodeSystem/MyValueSet|code20&subject=Patient/{{context.patientId}}";
+
+        assertNotNull(actual);
+        assertEquals(actual.size(), 5);
+        assertEquals(actual.get(0), expectedQuery1);
+        assertEquals(actual.get(1), expectedQuery2);
+        assertEquals(actual.get(2), expectedQuery3);
+        assertEquals(actual.get(3), expectedQuery4);
+        assertEquals(actual.get(4), expectedQuery5);
+    }
+
+    @Test
+    void testMaxCodesPerQueryNull() {
+        ValueSet valueSet = getTestValueSet("MyValueSet", 21);
+
+        org.hl7.fhir.r4.model.Bundle valueSetBundle = new org.hl7.fhir.r4.model.Bundle();
+        valueSetBundle.setType(Bundle.BundleType.SEARCHSET);
+
+        Bundle.BundleEntryComponent entry = new Bundle.BundleEntryComponent();
+        entry.setResource(valueSet);
+        valueSetBundle.addEntry(entry);
+
+        mockFhirRead("/ValueSet?url=http%3A%2F%2Fmyterm.com%2Ffhir%2FValueSet%2FMyValueSet", valueSetBundle);
+        mockFhirRead("/ValueSet/MyValueSet/$expand", valueSet);
+
+        DataRequirement dataRequirement = getCodeFilteredDataRequirement("Observation", "category", valueSet);
+
+        this.generator.setExpandValueSets(true);
+        this.generator.setQueryBatchThreshold(5);
+        this.contextValues.put("Patient", "{{context.patientId}}");
+        java.util.List<String> actual = this.generator.generateFhirQueries(dataRequirement, this.evaluationDateTime, this.contextValues, this.parameters, null);
+
+        String expectedQuery1 = "Observation?category=http://myterm.com/fhir/CodeSystem/MyValueSet|code0,http://myterm.com/fhir/CodeSystem/MyValueSet|code1,http://myterm.com/fhir/CodeSystem/MyValueSet|code10,http://myterm.com/fhir/CodeSystem/MyValueSet|code11,http://myterm.com/fhir/CodeSystem/MyValueSet|code12,http://myterm.com/fhir/CodeSystem/MyValueSet|code13,http://myterm.com/fhir/CodeSystem/MyValueSet|code14,http://myterm.com/fhir/CodeSystem/MyValueSet|code15,http://myterm.com/fhir/CodeSystem/MyValueSet|code16,http://myterm.com/fhir/CodeSystem/MyValueSet|code17,http://myterm.com/fhir/CodeSystem/MyValueSet|code18,http://myterm.com/fhir/CodeSystem/MyValueSet|code19,http://myterm.com/fhir/CodeSystem/MyValueSet|code2,http://myterm.com/fhir/CodeSystem/MyValueSet|code20,http://myterm.com/fhir/CodeSystem/MyValueSet|code3,http://myterm.com/fhir/CodeSystem/MyValueSet|code4,http://myterm.com/fhir/CodeSystem/MyValueSet|code5,http://myterm.com/fhir/CodeSystem/MyValueSet|code6,http://myterm.com/fhir/CodeSystem/MyValueSet|code7,http://myterm.com/fhir/CodeSystem/MyValueSet|code8,http://myterm.com/fhir/CodeSystem/MyValueSet|code9&subject=Patient/{{context.patientId}}";
+
+        assertNotNull(actual);
+        assertEquals(actual.size(), 1);
+        assertEquals(actual.get(0), expectedQuery1);
+    }
+
+    @Test
+    void testBatchQueryThresholdNull() {
+        ValueSet valueSet = getTestValueSet("MyValueSet", 21);
+
+        org.hl7.fhir.r4.model.Bundle valueSetBundle = new org.hl7.fhir.r4.model.Bundle();
+        valueSetBundle.setType(Bundle.BundleType.SEARCHSET);
+
+        Bundle.BundleEntryComponent entry = new Bundle.BundleEntryComponent();
+        entry.setResource(valueSet);
+        valueSetBundle.addEntry(entry);
+
+        mockFhirRead("/ValueSet?url=http%3A%2F%2Fmyterm.com%2Ffhir%2FValueSet%2FMyValueSet", valueSetBundle);
+        mockFhirRead("/ValueSet/MyValueSet/$expand", valueSet);
+
+        DataRequirement dataRequirement = getCodeFilteredDataRequirement("Observation", "category", valueSet);
+
+        this.generator.setExpandValueSets(true);
+        this.generator.setMaxCodesPerQuery(2);
+
+        this.contextValues.put("Patient", "{{context.patientId}}");
+        java.util.List<String> actual = this.generator.generateFhirQueries(dataRequirement, this.evaluationDateTime, this.contextValues, this.parameters, null);
+
+        assertNotNull(actual);
+        assertEquals(actual.size(), 11);
+    }
 }

--- a/engine.fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/retrieve/TestRestFhirRetrieveProvider.java
+++ b/engine.fhir/src/test/java/org/opencds/cqf/cql/engine/fhir/retrieve/TestRestFhirRetrieveProvider.java
@@ -71,7 +71,7 @@ public class TestRestFhirRetrieveProvider extends R4FhirTest {
         Integer expected = 100;
         provider.setPageSize(expected);
         BaseFhirQueryGenerator fhirQueryGenerator = FhirQueryGeneratorFactory.create(getModelResolver(CLIENT.getFhirContext().getVersion().getVersion()),
-            provider.searchParameterResolver, provider.getTerminologyProvider(), null, null, expected);
+            provider.searchParameterResolver, provider.getTerminologyProvider(), null, null, expected, null);
 
         SearchParameterMap map = fhirQueryGenerator.getBaseMap(null, null, null, null);
         assertEquals(map.getCount(), expected);


### PR DESCRIPTION
Added the queryBatchThreshold configuration point and modified the FhirQueryGenerator to be aware of and respect that configuration. 

If maxCodesPerQuery is set (i.e., not null and > 0), then the generator will chunk FhirQueries based on that setting - a new query every <maxCodesPerQuery> codes. The queryBatchThreshold setting is a mechanism for saying that if the result of that chunking is a number of queries that exceeds <queryBatchThreshold> then omit the code/terminology constraint portion of the Fhir Query.